### PR TITLE
Update metadata to match Bandcamp release

### DIFF
--- a/metadata.csv
+++ b/metadata.csv
@@ -222,8 +222,8 @@ Thanks for the ID, u/agentleBout!",21,0,1,3621,0,0,0,0,147,147,FALSE,FALSE,FALSE
 11,1:00:21,29:05,Karma Police 11-1 (Mansfield) [live - 14 August 1996],Live at Mansfield 1996,21,0,1,3621,5,29,0,1745,2007,262,FALSE,FALSE,FALSE,FALSE,FALSE,11
 11,1:00:21,33:27,Service [Thom solo] 🌚,Thom solo acoustic recording,21,0,1,3621,27,33,0,2007,2178,171,TRUE,FALSE,FALSE,FALSE,FALSE,12
 11,1:00:21,36:18,‘Jaz’ Song [Thom solo] 🌚,Thom acoustic solo recording,21,0,1,3621,18,36,0,2178,2356,178,TRUE,FALSE,FALSE,FALSE,FALSE,13
-11,1:00:21,39:16,Let Down 11-1 (Galway) [live - 28 July 1996],"Live early version, an organ instead of Jonny at the ending",21,0,1,3621,16,39,0,2356,2675,319,FALSE,FALSE,FALSE,FALSE,FALSE,14
-11,1:00:21,44:35,[tape blip - (Citizen Cane Intro)],"Very droney,  a recording of one of them playing maybe an organ or something else",21,0,1,3621,35,44,0,2675,2496,-179,FALSE,FALSE,FALSE,FALSE,FALSE,15
+11,1:00:21,39:16,Let Down 11-1 (Galway) [live - 28 July 1996],"Live early version, an organ instead of Jonny at the ending",21,0,1,3621,16,39,0,2356,2495,139,FALSE,FALSE,FALSE,FALSE,FALSE,14
+11,1:00:21,41:35,[tape blip - (Citizen Cane Intro)],"Very droney,  a recording of one of them playing maybe an organ or something else",21,0,1,3621,35,41,0,2495,2496,1,FALSE,FALSE,FALSE,FALSE,FALSE,15
 11,1:00:21,41:36,Let Down 11-2 (East Rutherford) [live - 19 August 1996],"Another live recording, early version",21,0,1,3621,36,41,0,2496,2967,471,FALSE,FALSE,FALSE,FALSE,FALSE,16
 11,1:00:21,49:27,Paranoid Android 11-2 (East Rutherford) [live - 19 August 1996],Live early version; I think this one could be the Hershey stadium in 1996,21,0,1,3621,27,49,0,2967,3382,415,FALSE,FALSE,FALSE,FALSE,FALSE,17
 11,1:00:21,56:22,Karma Police 11-2 (East Rutherford) [live - 19 August 1996],"Same show for sure, live and early version",21,0,1,3621,22,56,0,3382,3621,239,FALSE,FALSE,FALSE,FALSE,FALSE,18

--- a/metadata.csv
+++ b/metadata.csv
@@ -1,366 +1,349 @@
 "disc","disc_runtime","time","title","notes","disc_seconds","disc_minutes","disc_hours","disc_runtime_seconds","seconds","minutes","hours","start_time","end_time","length","bedroom","favorite","holy_grail","white_cassette","fan_name","track_number"
-1,"1:11:14","0:00","Silence (1-1)",NA,14,11,1,4274,0,0,0,0,14,14,FALSE,FALSE,FALSE,FALSE,FALSE,1
-1,"1:11:14","0:14","Exit Music / Life in a Glasshouse (Thom Solo) (1-2) 🌚","Interestingly, Exit Music transitions into LIAGH as if they were 1 song",14,11,1,4274,14,0,0,14,112,98,TRUE,FALSE,FALSE,FALSE,FALSE,2
-1,"1:11:14","1:52","I Promise 1-1 (Early Rehearsal) (1-3)","“I won’t fool around no more…”",14,11,1,4274,52,1,0,112,348,236,FALSE,FALSE,FALSE,FALSE,FALSE,3
-1,"1:11:14","5:48","Attention (Early Rehearsal) (1-4)","Full band",14,11,1,4274,48,5,0,348,649,301,FALSE,FALSE,FALSE,FALSE,FALSE,4
-1,"1:11:14","10:49","Electioneering 1-1 (Early Rehearsal) (1-5)","Early version",14,11,1,4274,49,10,0,649,799,150,FALSE,FALSE,FALSE,FALSE,FALSE,5
-1,"1:11:14","13:19","Lift 1-1 (Early Live) (1-6)","Early version",14,11,1,4274,19,13,0,799,955,156,FALSE,FALSE,FALSE,FALSE,FALSE,6
-1,"1:11:14","15:55","True Love Waits (Full Band) (1-7) ⭐🤤","Features a full band",14,11,1,4274,55,15,0,955,1347,392,FALSE,TRUE,TRUE,FALSE,FALSE,7
-1,"1:11:14","22:27","Unreleased Thom Solo (Acoustic) 1-1 ('Little by Little Crawls Away') (1-8) 🌚","Possibly a Thom solo recording of “Little By Little” (different from TKOL track) due to the lyrics",14,11,1,4274,27,22,0,1347,1418,71,TRUE,FALSE,FALSE,FALSE,FALSE,8
-1,"1:11:14","23:38","Unknown Movie Snippet (1-9)",NA,14,11,1,4274,38,23,0,1418,1465,47,FALSE,FALSE,FALSE,FALSE,FALSE,9
-1,"1:11:14","24:25","Lift 1-2 (Live First Performance) (1-10)","First performance!",14,11,1,4274,25,24,0,1465,1710,245,FALSE,FALSE,FALSE,FALSE,FALSE,10
-1,"1:11:14","28:30","Electioneering 1-1 (Early Live) (1-11)",NA,14,11,1,4274,30,28,0,1710,1931,221,FALSE,FALSE,FALSE,FALSE,FALSE,11
-1,"1:11:14","32:11","I Promise 1-1 (Early Live) (1-12)",NA,14,11,1,4274,11,32,0,1931,2194,263,FALSE,FALSE,FALSE,FALSE,FALSE,12
-1,"1:11:14","36:34","Unreleased Thom Solo (Acoustic) 1-2 (1-13) 🌚","Solo Thom on acoustic",14,11,1,4274,34,36,0,2194,2294,100,TRUE,FALSE,FALSE,FALSE,FALSE,13
-1,"1:11:14","38:14","Airbag 1-1 (Early Rehearsal) (1-14)","Early version",14,11,1,4274,14,38,0,2294,2608,314,FALSE,FALSE,FALSE,FALSE,FALSE,14
-1,"1:11:14","43:28","Airbag 1-2 Fragment with Feedback and Reverb (1-15)","This version has a long reverb-y intro",14,11,1,4274,28,43,0,2608,2640,32,FALSE,FALSE,FALSE,FALSE,FALSE,15
-1,"1:11:14","44:00","Airbag 1-3 (Early Rehearsal with Feedback Intro) (1-16)",NA,14,11,1,4274,0,44,0,2640,2913,273,FALSE,FALSE,FALSE,FALSE,FALSE,16
-1,"1:11:14","48:33","I Promise 1-2 (Early Live) (1-17)",NA,14,11,1,4274,33,48,0,2913,3156,243,FALSE,FALSE,FALSE,FALSE,FALSE,17
-1,"1:11:14","52:36","Unreleased Thom Solo (Acoustic) 1-3 ('I Wanna Sing Along') (1-18) 🌚",NA,14,11,1,4274,36,52,0,3156,3205,49,TRUE,FALSE,FALSE,FALSE,FALSE,18
-1,"1:11:14","53:25","I Promise 1-3 (Early Live) (1-19)",NA,14,11,1,4274,25,53,0,3205,3448,243,FALSE,FALSE,FALSE,FALSE,FALSE,19
-1,"1:11:14","57:28","Electioneering 1-2 (Early Live with Acoustic Guitar and Harmonies) (1-20)",NA,14,11,1,4274,28,57,0,3448,3663,215,FALSE,FALSE,FALSE,FALSE,FALSE,20
-1,"1:11:14","1:01:03","Paranoid Android (Early Rehearsal) (1-21)","Early version; different lyrics",14,11,1,4274,3,1,1,3663,3942,279,FALSE,FALSE,FALSE,FALSE,FALSE,21
-1,"1:11:14","1:05:42","Airbag 1-4 (Early Rehearsal, Cut Intro) (1-22)","Clip starts midway, sounds like the complete version",14,11,1,4274,42,5,1,3942,4067,125,FALSE,FALSE,FALSE,FALSE,FALSE,22
-1,"1:11:14","1:07:47","Electioneering 1-3 (Early Live with Acoustic Guitar and Harmonies) (1-23)","Ed/Jonny harmonizing? Cuts off early",14,11,1,4274,47,7,1,4067,4258,191,FALSE,FALSE,FALSE,FALSE,FALSE,23
-1,"1:11:14","1:10:58","Silence (1-24)","Silence be like. Silence noises.",14,11,1,4274,58,10,1,4258,0,-4258,FALSE,FALSE,FALSE,FALSE,FALSE,24
-2,"1:04:38","0:00","Silence (2-1)",NA,38,4,1,3878,0,0,0,0,5,5,FALSE,FALSE,FALSE,FALSE,FALSE,1
-2,"1:04:38","0:05","Band Talking (2-2)",NA,38,4,1,3878,5,0,0,5,25,20,FALSE,FALSE,FALSE,FALSE,FALSE,2
-2,"1:04:38","0:25","No Surprises (Soundcheck Demo) (2-3) 📼","Early version; already heard in the cassette",38,4,1,3878,25,0,0,25,185,160,FALSE,FALSE,FALSE,TRUE,FALSE,3
-2,"1:04:38","3:05","Unreleased Thom Solo 2-1 (Acoustic) (If I Get My Head Out Of This ...) (2-4) 🌚","Song cuts off midway",38,4,1,3878,5,3,0,185,344,159,TRUE,FALSE,FALSE,FALSE,FALSE,4
-2,"1:04:38","5:44","Unreleased Thom Solo 2-2 (Acoustic) (I Think That I Will ...) (2-5) 🌚","Groovy guitar riff",38,4,1,3878,44,5,0,344,518,174,TRUE,FALSE,FALSE,FALSE,FALSE,5
-2,"1:04:38","8:38","Unreleased Thom Solo 2-3 (Acoustic) (I Want You To Know) (2-6) 🌚","Thom solo acoustic.",38,4,1,3878,38,8,0,518,741,223,TRUE,FALSE,FALSE,FALSE,FALSE,6
-2,"1:04:38","12:21","Field Recording of Outdoor Sounds (2-7)",NA,38,4,1,3878,21,12,0,741,774,33,FALSE,FALSE,FALSE,FALSE,FALSE,7
-2,"1:04:38","12:54","Unreleased Thom Solo 2-4 (Acoustic) (I'm So Good At Everyone's ...) (2-8) 🌚","Thom solo acoustic",38,4,1,3878,54,12,0,774,931,157,TRUE,FALSE,FALSE,FALSE,FALSE,8
-2,"1:04:38","15:31","Exit Music (Thom Solo Acoustic, Early Lyrics) (2-9)","This was a snippet included in the previews before all 18 discs leaked",38,4,1,3878,31,15,0,931,1158,227,FALSE,FALSE,FALSE,FALSE,FALSE,9
-2,"1:04:38","19:18","Unreleased Thom Solo 2-5 (Acoustic) (You Stay Away But You're Too Good) (2-10) 🌚","Thom solo acoustic",38,4,1,3878,18,19,0,1158,1288,130,TRUE,FALSE,FALSE,FALSE,FALSE,10
-2,"1:04:38","21:28","A Reminder (Czech Public Transport Field Recording) (2-11)","Ladies chattering in a foreign language & sounds of public transportation",38,4,1,3878,28,21,0,1288,1503,215,FALSE,FALSE,FALSE,FALSE,FALSE,11
-2,"1:04:38","25:03","TV Show Recording Mentioning Dogwander (2-12)","An audio clip taken from Dynomutt, Dog Wonder, a Hanna-Barbera show. This might also be the inspiration for Dogwander",38,4,1,3878,3,25,0,1503,1709,206,FALSE,FALSE,FALSE,FALSE,FALSE,12
-2,"1:04:38","28:29","Field Recording of Transportation (2-13)",NA,38,4,1,3878,29,28,0,1709,1755,46,FALSE,FALSE,FALSE,FALSE,FALSE,13
-2,"1:04:38","29:15","Unreleased Thom Solo 2-6 (Acoustic) (He Wants To Save His) (2-14) 🌚","The song is interrupted a few times by some knocking; could mean retakes of a song
-“Is there anyone at all?”",38,4,1,3878,15,29,0,1755,1796,41,TRUE,FALSE,FALSE,FALSE,FALSE,14
-2,"1:04:38","29:56","Unreleased Thom Solo 2-6 (Acoustic) (He Wants To Save His) (2) (2-15) 🌚","Another take",38,4,1,3878,56,29,0,1796,1969,173,TRUE,FALSE,FALSE,FALSE,FALSE,15
-2,"1:04:38","32:49","Motion Picture Soundtrack 2-1 (Early Rehearsal) (2-16) 🤤","Early version; sounds pretty Bends-y",38,4,1,3878,49,32,0,1969,2279,310,FALSE,TRUE,FALSE,FALSE,FALSE,16
-2,"1:04:38","37:59","Exit Music 2-1 (Full Band Rehearsal/Jam) (2-17)","Similar chord progression to Exit Music",38,4,1,3878,59,37,0,2279,2399,120,FALSE,FALSE,FALSE,FALSE,FALSE,17
-2,"1:04:38","39:59","Unreleased full band rehearsal/jam 2-1 (2-18)","Has some vocals to an unknown song. Drums sound similar to Pearly",38,4,1,3878,59,39,0,2399,2441,42,FALSE,FALSE,FALSE,FALSE,FALSE,18
-2,"1:04:38","40:41","Let Down (Early Rehearsal) (2-19)","Early version; some jamming at the end",38,4,1,3878,41,40,0,2441,2737,296,FALSE,FALSE,FALSE,FALSE,FALSE,19
-2,"1:04:38","45:37","Motion Picture Soundtrack 2-2 (Early Rehearsal) (2-20)",NA,38,4,1,3878,37,45,0,2737,3032,295,FALSE,FALSE,FALSE,FALSE,FALSE,20
-2,"1:04:38","50:32","Airbag (Early Rehearsal with False Start) (2-21)","A false start at the beginning",38,4,1,3878,32,50,0,3032,3329,297,FALSE,FALSE,FALSE,FALSE,FALSE,21
-2,"1:04:38","55:29","Unreleased ‘Hurts To Walk (My Funky Cloak)’ (Full Band Rehearsal) [Fan Title] (2-22) ✏️🤤","Fan name by belargu
-This is the goofiest shit I’ve ever heard lol I LOVE it",38,4,1,3878,29,55,0,3329,3580,251,FALSE,TRUE,FALSE,FALSE,TRUE,22
-2,"1:04:38","59:40","Unreleased ‘Hurts To Walk (My Funky Cloak)’ (Full Band Rehearsal) [Fan Title] Take 2 (2-23)","Seems to be take 2 of the previous track",38,4,1,3878,40,59,0,3580,3788,208,FALSE,FALSE,FALSE,FALSE,FALSE,23
-2,"1:04:38","1:03:08","Unreleased Full Band Jam 2-1 (2-24)","Snippet of “Attention”",38,4,1,3878,8,3,1,3788,3823,35,FALSE,FALSE,FALSE,FALSE,FALSE,24
-2,"1:04:38","1:03:43","Unreleased Full Band Jam 2-1 (2-25)",NA,38,4,1,3878,43,3,1,3823,10,-3813,FALSE,FALSE,FALSE,FALSE,FALSE,25
-3,"1:08:57","0:10","Unreleased Flute and Sitar Jam (3-1)","This snippet is from Ahir Bhairav/Nat Bhairav - Hariprasad Chaurasia & Brij Bhushan
-Kabra & Shivkumar Sharma",57,8,1,4137,10,0,0,10,145,135,FALSE,FALSE,FALSE,FALSE,FALSE,1
-3,"1:08:57","2:25","I Promise (Live, Cut Intro) (3-2)","Cut intro",57,8,1,4137,25,2,0,145,218,73,FALSE,FALSE,FALSE,FALSE,FALSE,2
-3,"1:08:57","3:38","Motion Picture Soundtrack (Live, 4/10/96, Rockville MD, Just Passin' Thru Radio Session) (3-3)","Solo Thom on electric guitar
-According to redditor /u/EsotericCD, this is from the 4/10/96 “Just Passin’ Thru” radio session in Rockville, MD, but is a “FAR FAR better sounding version of it than the off-air recording we used to have.” Thanks for the ID!",57,8,1,4137,38,3,0,218,426,208,FALSE,FALSE,FALSE,FALSE,FALSE,3
-3,"1:08:57","7:06","I Promise (First Live Performance, Duplicate, Thom Intro) (3-4)","First ever live performance, announcement at beginning",57,8,1,4137,6,7,0,426,682,256,FALSE,FALSE,FALSE,FALSE,FALSE,4
-3,"1:08:57","11:22","Unused String Arrangement for Unknown Song (3-5)","Possibly for CUTW? Most likely a snippet from an existing score",57,8,1,4137,22,11,0,682,731,49,FALSE,FALSE,FALSE,FALSE,FALSE,5
-3,"1:08:57","12:11","Nude (Full Band Version) (3-6)","Different from the cassette version.",57,8,1,4137,11,12,0,731,972,241,FALSE,FALSE,FALSE,FALSE,FALSE,6
-3,"1:08:57","16:12","Metallic percussive noises (3-7)","The following snippets are just instrumental bits & pieces",57,8,1,4137,12,16,0,972,1014,42,FALSE,FALSE,FALSE,FALSE,FALSE,7
-3,"1:08:57","16:54","Synthesizer solo (3-8)",NA,57,8,1,4137,54,16,0,1014,1093,79,FALSE,FALSE,FALSE,FALSE,FALSE,8
-3,"1:08:57","18:13","Saxophone with tape manipulated drums (3-9)","This is a snippet from Joe Henderson - El Barrio.",57,8,1,4137,13,18,0,1093,1175,82,FALSE,FALSE,FALSE,FALSE,FALSE,9
-3,"1:08:57","19:35","Unreleased delayed piano song, synth brass and reversed drums/sub bass (3-10)",NA,57,8,1,4137,35,19,0,1175,1580,405,FALSE,FALSE,FALSE,FALSE,FALSE,10
-3,"1:08:57","26:20","Unreleased synth bass and drum machine song (3-11)",NA,57,8,1,4137,20,26,0,1580,1811,231,FALSE,FALSE,FALSE,FALSE,FALSE,11
-3,"1:08:57","30:11","Unreleased Thom solo (Acoustic) 3-1 (Maybe this is love…) (3-12) 🌚",NA,57,8,1,4137,11,30,0,1811,1948,137,TRUE,FALSE,FALSE,FALSE,FALSE,12
-3,"1:08:57","32:28","Unreleased Thom solo (Acoustic) 3-2 (I Must Control It) (3-13) 🌚",NA,57,8,1,4137,28,32,0,1948,2115,167,TRUE,FALSE,FALSE,FALSE,FALSE,13
-3,"1:08:57","35:15","Unreleased delayed piano song, Take 2 (3-14)",NA,57,8,1,4137,15,35,0,2115,2359,244,FALSE,FALSE,FALSE,FALSE,FALSE,14
-3,"1:08:57","39:19","Unreleased Thom solo (Acoustic) 3-3 (It’s gonna be done) (3-15) 🌚",NA,57,8,1,4137,19,39,0,2359,2535,176,TRUE,FALSE,FALSE,FALSE,FALSE,15
-3,"1:08:57","42:15","Unreleased Thom solo (Acoustic) 3-4 (Can anyone help us) (3-16) 🌚",NA,57,8,1,4137,15,42,0,2535,2791,256,TRUE,FALSE,FALSE,FALSE,FALSE,16
-3,"1:08:57","46:31","Exit Music (solo Thom, alternate arrangement/rhythm and lyrics) (3-17) 🌚","Very early version",57,8,1,4137,31,46,0,2791,3053,262,TRUE,FALSE,FALSE,FALSE,FALSE,17
-3,"1:08:57","50:53","Paranoid Android (Early Rehearsal, Instrumental Fragment) (3-18)","Very early, & only a section
-(before “you don’t remember, why don’t you remember my name?” excerpt live)",57,8,1,4137,53,50,0,3053,3145,92,FALSE,FALSE,FALSE,FALSE,FALSE,18
-3,"1:08:57","52:25","No Surprises (Early Soundcheck) (3-19)","Soundcheck",57,8,1,4137,25,52,0,3145,3348,203,FALSE,FALSE,FALSE,FALSE,FALSE,19
-3,"1:08:57","55:48","Unreleased Full Band Jam with Sonic Youth-like Guitar, 'Thom's Screechy Song' (3-20) ✏️","Fan name by The Bumstickler",57,8,1,4137,48,55,0,3348,3654,306,FALSE,FALSE,FALSE,FALSE,TRUE,20
-3,"1:08:57","1:00:54","Unreleased delayed piano song with more layers, Take 3 (3-21)",NA,57,8,1,4137,54,0,1,3654,3976,322,FALSE,FALSE,FALSE,FALSE,FALSE,21
-3,"1:08:57","1:06:16","Unreleased Thom solo (Acoustic) 3-5 (I Don’t Get It) (3-22) 🌚",NA,57,8,1,4137,16,6,1,3976,5,-3971,TRUE,FALSE,FALSE,FALSE,FALSE,22
-4,"00:57:29","0:05","Unused bass/organ (4-1)","Possibly Man of War and or meant for Airbag at some point.",29,57,0,3449,5,0,0,5,101,96,FALSE,FALSE,FALSE,FALSE,FALSE,1
-4,"00:57:29","1:41","No Surprises (Early Rehearsal/Demo) (4-2)","Crazy outro",29,57,0,3449,41,1,0,101,356,255,FALSE,FALSE,FALSE,FALSE,FALSE,2
-4,"00:57:29","5:56","Bullet Proof (Live Snippet) (4-3)","3 second blip",29,57,0,3449,56,5,0,356,365,9,FALSE,FALSE,FALSE,FALSE,FALSE,3
-4,"00:57:29","6:05","True Love Waits (Unfinished Backing Track) (4-4)","Early instrumental with drum machine, acoustic guitar, and bg synth.",29,57,0,3449,5,6,0,365,663,298,FALSE,FALSE,FALSE,FALSE,FALSE,4
-4,"00:57:29","11:03","Unreleased drum machine with A Reminder chime sample (4-5)","Very staticy midway, ends with drum solo. Contains crowd noises meant for A Reminder.",29,57,0,3449,3,11,0,663,880,217,FALSE,FALSE,FALSE,FALSE,FALSE,5
-4,"00:57:29","14:40","Unreleased drum machine with A Reminder chime sample, Take 2 (4-6)",NA,29,57,0,3449,40,14,0,880,1105,225,FALSE,FALSE,FALSE,FALSE,FALSE,6
-4,"00:57:29","18:25","Paranoid Android (Early Rehearsal, Ambition section, several attempts) (4-7)","Starts at “You don’t remember... “ section, Thom stops band halfway through to talk through changes. Probably a practice. This includes multiple takes & jamming",29,57,0,3449,25,18,0,1105,1642,537,FALSE,FALSE,FALSE,FALSE,FALSE,7
-4,"00:57:29","27:22","Motion Picture Soundtrack (Slow Full Band Version), Take 1 (4-8)",NA,29,57,0,3449,22,27,0,1642,1987,345,FALSE,FALSE,FALSE,FALSE,FALSE,8
-4,"00:57:29","33:07","Motion Picture Soundtrack (Slow Full Band Version), Take 2 (4-9)",NA,29,57,0,3449,7,33,0,1987,2292,305,FALSE,FALSE,FALSE,FALSE,FALSE,9
-4,"00:57:29","38:12","Airbag (Early Rehearsal, Different Intro) (4-10)","Early full band version. Very rough, longer outro",29,57,0,3449,12,38,0,2292,2600,308,FALSE,FALSE,FALSE,FALSE,FALSE,10
-4,"00:57:29","43:20","Airbag (Early Rehearsal, Take 2) (4-11)",NA,29,57,0,3449,20,43,0,2600,2889,289,FALSE,FALSE,FALSE,FALSE,FALSE,11
-4,"00:57:29","48:09","The Tourist (Early Rehearsal, Alt. Melody) (4-12)",NA,29,57,0,3449,9,48,0,2889,3067,178,FALSE,FALSE,FALSE,FALSE,FALSE,12
-4,"00:57:29","51:07","The Tourist (Early Rehearsal, Take 2) (4-13)",NA,29,57,0,3449,7,51,0,3067,3129,62,FALSE,FALSE,FALSE,FALSE,FALSE,13
-4,"00:57:29","52:09","The Tourist (Early Rehearsal with Chorus, Take 3) (4-14)",NA,29,57,0,3449,9,52,0,3129,3201,72,FALSE,FALSE,FALSE,FALSE,FALSE,14
-4,"00:57:29","53:21","Palo Alto (Early Rehearsal) (4-15)","Early demo with slightly different lyrics. Chorus has slightly different melody",29,57,0,3449,21,53,0,3201,4,-3197,FALSE,FALSE,FALSE,FALSE,FALSE,15
-5,"00:57:02","0:04","Drum solo and chatter with brief Paranoid Android discussion (5-1)","Unstructured jam; goofing around",2,57,0,3422,4,0,0,4,68,64,FALSE,FALSE,FALSE,FALSE,FALSE,1
-5,"00:57:02","1:08","Paranoid Android (Early Rehearsal, 'Rain down' section) (5-2)","Practice run from “rain down” section",2,57,0,3422,8,1,0,68,336,268,FALSE,FALSE,FALSE,FALSE,FALSE,2
-5,"00:57:02","5:36","Paranoid Android (Original Long Version, Full Length Early Rehearsal) (5-3) ⭐","11 minute early version w/ outro jam",2,57,0,3422,36,5,0,336,830,494,FALSE,FALSE,TRUE,FALSE,FALSE,3
-5,"00:57:02","13:50","Unreleased full band song/jam with tape effects (5-4)",NA,2,57,0,3422,50,13,0,830,1006,176,FALSE,FALSE,FALSE,FALSE,FALSE,4
-5,"00:57:02","16:46","Unreleased full band song/jam, ascending chord progression (5-5)","Another snippet of “Attention”",2,57,0,3422,46,16,0,1006,1075,69,FALSE,FALSE,FALSE,FALSE,FALSE,5
-5,"00:57:02","17:55","Unreleased full band song/jam with synth (False Start) (5-6)","Gets fast forwarded",2,57,0,3422,55,17,0,1075,1553,478,FALSE,FALSE,FALSE,FALSE,FALSE,6
-5,"00:57:02","25:53","Unreleased full band rock song (When I Get Bored Give Me One of Those) (5-7)","Has vocals",2,57,0,3422,53,25,0,1553,1809,256,FALSE,FALSE,FALSE,FALSE,FALSE,7
-5,"00:57:02","30:09","No Surprises (Early Rehearsal), Take 1 (5-8)","Early version, full band",2,57,0,3422,9,30,0,1809,2037,228,FALSE,FALSE,FALSE,FALSE,FALSE,8
-5,"00:57:02","33:57","No Surprises (Early Rehearsal), Take 2 (5-9)","Early version, full band",2,57,0,3422,57,33,0,2037,2262,225,FALSE,FALSE,FALSE,FALSE,FALSE,9
-5,"00:57:02","37:42","Attention (5-10)","Unreleased full band song",2,57,0,3422,42,37,0,2262,2561,299,FALSE,FALSE,FALSE,FALSE,FALSE,10
-5,"00:57:02","42:41","Wake up call recording (5-11)","“We have registered your call”",2,57,0,3422,41,42,0,2561,2637,76,FALSE,FALSE,FALSE,FALSE,FALSE,11
-5,"00:57:02","43:57","Unreleased Thom solo (Acoustic), Lo-fi 5-1, 'I Won't Be Halfway Down,' (5-12) 🌚","Cheap mic. “I won’t be halfway down”",2,57,0,3422,57,43,0,2637,2735,98,TRUE,FALSE,FALSE,FALSE,FALSE,12
-5,"00:57:02","45:35","Unreleased Thom solo (Acoustic), Lo-fi 5-2, 'One Thing,' (5-13) 🌚","Cheap mic. “I’m going to get you back again”",2,57,0,3422,35,45,0,2735,2809,74,TRUE,FALSE,FALSE,FALSE,FALSE,13
-5,"00:57:02","46:49","Fast forwarding through tape (5-14)","Tape fast forwards a bit",2,57,0,3422,49,46,0,2809,2818,9,FALSE,FALSE,FALSE,FALSE,FALSE,14
-5,"00:57:02","46:58","Unreleased Thom solo (Acoustic), Lo-fi 5-3, 'You Don't See The Signs,' (5-15) 🌚","Cheap mic. “You don’t see the signs”",2,57,0,3422,58,46,0,2818,2914,96,TRUE,FALSE,FALSE,FALSE,FALSE,15
-5,"00:57:02","48:34","""Unreleased Thom solo (Acoustic), Lo-fi 5-4 (5-16)"" 🌚","Cheap mic.",2,57,0,3422,34,48,0,2914,2994,80,TRUE,FALSE,FALSE,FALSE,FALSE,16
-5,"00:57:02","49:54","Nude (Thom solo Acoustic), Lo-fi (5-17) 🌚","Thom solo acoustic demo (early)",2,57,0,3422,54,49,0,2994,3194,200,TRUE,FALSE,FALSE,FALSE,FALSE,17
-5,"00:57:02","53:14","Choir, Lo-fi (5-18)","Lo-fi. Recorded from a TV show",2,57,0,3422,14,53,0,3194,3224,30,FALSE,FALSE,FALSE,FALSE,FALSE,18
-5,"00:57:02","53:44","Paranoid Android fragment (Early Rehearsal, Thom/Jonny only) (5-19)","Early Thom/Jonny version",2,57,0,3422,44,53,0,3224,3247,23,FALSE,FALSE,FALSE,FALSE,FALSE,19
-5,"00:57:02","54:07","Drum jamming, Lo-fi (5-20)","Lo-fi",2,57,0,3422,7,54,0,3247,3373,126,FALSE,FALSE,FALSE,FALSE,FALSE,20
-5,"00:57:02","56:13","Piano Sketch by Jonny (5-21) 📼","Included in the OKNOTOK cassette",2,57,0,3422,13,56,0,3373,9,-3364,FALSE,FALSE,FALSE,TRUE,FALSE,21
-6,"00:35:51","0:09","Unreleased solo guitar, Lo-fi (6-1)","Crunchy",51,35,0,2151,9,0,0,9,51,42,FALSE,FALSE,FALSE,FALSE,FALSE,1
-6,"00:35:51","0:51","Solo drumming (6-2)","Drummy",51,35,0,2151,51,0,0,51,81,30,FALSE,FALSE,FALSE,FALSE,FALSE,2
-6,"00:35:51","1:21","Unreleased Thom solo (Acoustic) 6-1, 'And if it...' (6-3) 🌚","Thom pls enunciate so I can figure out a fan name for this kplsthx",51,35,0,2151,21,1,0,81,226,145,TRUE,FALSE,FALSE,FALSE,FALSE,3
-6,"00:35:51","3:46","Last Flowers (Thom solo Acoustic), Take 1 (6-4) 🤤🌚","Early version
-“No evaluations, no deliberations”",51,35,0,2151,46,3,0,226,323,97,TRUE,TRUE,FALSE,FALSE,FALSE,4
-6,"00:35:51","5:23","Unreleased Thom solo (Acoustic) 6-2, 'If I don't see him' (6-5) 🌚",NA,51,35,0,2151,23,5,0,323,480,157,TRUE,FALSE,FALSE,FALSE,FALSE,5
-6,"00:35:51","8:00","Unreleased Thom solo (Acoustic) 6-3, 'I Lost My Feeling' (6-6) 🌚","Seems to pick up from the previous song; maybe a retake",51,35,0,2151,0,8,0,480,636,156,TRUE,FALSE,FALSE,FALSE,FALSE,6
-6,"00:35:51","10:36","Last Flowers (Thom solo Acoustic), Take 2 (6-7) 🌚","This is a song by radiohead.",51,35,0,2151,36,10,0,636,855,219,TRUE,FALSE,FALSE,FALSE,FALSE,7
-6,"00:35:51","14:15","Life in a Glasshouse (Thom solo Acoustic, Very Early Version) (6-8) 🌚","Tin-can audio. Sounds like Life in a Glasshouse",51,35,0,2151,15,14,0,855,1081,226,TRUE,FALSE,FALSE,FALSE,FALSE,8
-6,"00:35:51","18:01","Unreleased Thom solo (Acoustic) 6-4, Lo-fi (6-9) 🌚",NA,51,35,0,2151,1,18,0,1081,1209,128,TRUE,FALSE,FALSE,FALSE,FALSE,9
-6,"00:35:51","20:09","Unreleased Thom solo (Acoustic) 6-5, Lo-fi, 'We Don't Spend, We Don't Know' (6-10) 🌚","Thom interrupts the song to talk about letters; possibly a retake halfway through",51,35,0,2151,9,20,0,1209,1426,217,TRUE,FALSE,FALSE,FALSE,FALSE,10
-6,"00:35:51","23:46","Thom talks about old letters (6-11)",NA,51,35,0,2151,46,23,0,1426,1497,71,FALSE,FALSE,FALSE,FALSE,FALSE,11
-6,"00:35:51","24:57","Continuation of Unreleased Thom solo (Acoustic) 6-5, Lo-fi, 'We Don't Spend, We Don't Know' (6-10) (6-12) 🌚",NA,51,35,0,2151,57,24,0,1497,1556,59,TRUE,FALSE,FALSE,FALSE,FALSE,12
-6,"00:35:51","25:56","James Bond soundtrack excerpt (?) (6-13)","Includes many short snippets of movie soundtracks, some/all from James Bond. This lasts until the end",51,35,0,2151,56,25,0,1556,1766,210,FALSE,FALSE,FALSE,FALSE,FALSE,13
-6,"00:35:51","29:26","James Bond soundtrack excerpt (?) (6-14)",NA,51,35,0,2151,26,29,0,1766,1810,44,FALSE,FALSE,FALSE,FALSE,FALSE,14
-6,"00:35:51","30:10","Violin, unknown source (?) (6-15)",NA,51,35,0,2151,10,30,0,1810,1819,9,FALSE,FALSE,FALSE,FALSE,FALSE,15
-6,"00:35:51","30:19","Unknown soundtrack excerpt, string section (?) (6-16)",NA,51,35,0,2151,19,30,0,1819,1848,29,FALSE,FALSE,FALSE,FALSE,FALSE,16
-6,"00:35:51","30:48","Unknown soundtrack excerpt, strings and choir (?) (6-17)",NA,51,35,0,2151,48,30,0,1848,1919,71,FALSE,FALSE,FALSE,FALSE,FALSE,17
-6,"00:35:51","31:59","Unknown soundtrack excerpt, strings and full orchestra (6-18)",NA,51,35,0,2151,59,31,0,1919,1972,53,FALSE,FALSE,FALSE,FALSE,FALSE,18
-6,"00:35:51","32:52","Unknown soundtrack excerpt, more avant-garde (6-19)",NA,51,35,0,2151,52,32,0,1972,2022,50,FALSE,FALSE,FALSE,FALSE,FALSE,19
-6,"00:35:51","33:42","Unknown soundtrack excerpt, tribal-like drums (6-20)",NA,51,35,0,2151,42,33,0,2022,2093,71,FALSE,FALSE,FALSE,FALSE,FALSE,20
-6,"00:35:51","34:53","Unknown soundtrack excerpts, drums, bells and brass (6-21)",NA,51,35,0,2151,53,34,0,2093,2118,25,FALSE,FALSE,FALSE,FALSE,FALSE,21
-6,"00:35:51","35:18","Unknown soundtrack excerpts, somewhat jazz-y (6-22)",NA,51,35,0,2151,18,35,0,2118,9,-2109,FALSE,FALSE,FALSE,FALSE,FALSE,22
-7,"00:55:23","0:09","Unreleased Thom solo (Acoustic) 7-1, 'Leave your comments and reactions here,' (7-1) 🤤🌚","“Leave your comments and reactions here”",23,55,0,3323,9,0,0,9,162,153,TRUE,TRUE,FALSE,FALSE,FALSE,1
-7,"00:55:23","2:42","Last Flowers (Full Band Version) (7-2)","Full Band. Drop out or mixing error at 5:52",23,55,0,3323,42,2,0,162,439,277,FALSE,FALSE,FALSE,FALSE,FALSE,2
-7,"00:55:23","7:19","Melatonin (Alternate Studio Version) (7-3)","Alternate version or mix",23,55,0,3323,19,7,0,439,568,129,FALSE,FALSE,FALSE,FALSE,FALSE,3
-7,"00:55:23","9:28","""Unreleased full band song 7-1, 'You would do the same, thousand miles over' (7-4)","“You would do the same, thousand miles, wanted to believe in”",23,55,0,3323,28,9,0,568,701,133,FALSE,FALSE,FALSE,FALSE,FALSE,4
-7,"00:55:23","11:41","Unreleased full band jam 7-2 (7-5)","Might be a song fragment",23,55,0,3323,41,11,0,701,747,46,FALSE,FALSE,FALSE,FALSE,FALSE,5
-7,"00:55:23","12:27","Unreleased full band jam 7-3, organ and ride cymbal (7-6) 🤤","With organ and ride cymbal keeping time",23,55,0,3323,27,12,0,747,895,148,FALSE,TRUE,FALSE,FALSE,FALSE,6
-7,"00:55:23","14:55","Nigel AMS Delay + AMS Hello 📼 7-4 (7-7)","Both on the cassette.",23,55,0,3323,55,14,0,895,974,79,FALSE,FALSE,FALSE,TRUE,FALSE,7
-7,"00:55:23","16:14","Solo drums semi-processed through Moog (7-8)",NA,23,55,0,3323,14,16,0,974,1076,102,FALSE,FALSE,FALSE,FALSE,FALSE,8
-7,"00:55:23","17:56","Karma Police (Early Rehearsal, Electric Guitar, Alt. Lyrics) (7-9)","Very early, unfinished lyrics. “This is what you get when you fuck with me”",23,55,0,3323,56,17,0,1076,1330,254,FALSE,FALSE,FALSE,FALSE,FALSE,9
-7,"00:55:23","22:10","Unreleased full band song 7-5, 'Decided, You Don't Try' (7-10)","“You won’t try, I wanna go to the edge(?)”",23,55,0,3323,10,22,0,1330,1672,342,FALSE,FALSE,FALSE,FALSE,FALSE,10
-7,"00:55:23","27:52","Unreleased full band song 7-6, psychedelic guitar (7-11)","“Psychedelic-ish”",23,55,0,3323,52,27,0,1672,1721,49,FALSE,FALSE,FALSE,FALSE,FALSE,11
-7,"00:55:23","28:41","Airbag (Early Rehearsal, Heavier Rock Guitar Only) (7-12)","Very early guitar. Slower tempo, rock arrangement intro",23,55,0,3323,41,28,0,1721,1753,32,FALSE,FALSE,FALSE,FALSE,FALSE,12
-7,"00:55:23","29:13","Airbag (Early Rehearsal with Jam Intro) (7-13)","Funky rock jam turns into early Airbag, full band",23,55,0,3323,13,29,0,1753,1817,64,FALSE,FALSE,FALSE,FALSE,FALSE,13
-7,"00:55:23","30:17","Airbag (Early Rehearsal, Heavier
-Version) (7-14)🤤","Very early attempt #3",23,55,0,3323,17,30,0,1817,2104,287,FALSE,TRUE,FALSE,FALSE,FALSE,14
-7,"00:55:23","35:04","Let Down (Early Rehearsal) (7-15)","Early Let Down",23,55,0,3323,4,35,0,2104,2531,427,FALSE,FALSE,FALSE,FALSE,FALSE,15
-7,"00:55:23","42:11","Unreleased full band song 7-7, skronk funk, 'Something Got A Hold of Your Mind' (7-16)","Almost sounds like Last Flowers",23,55,0,3323,11,42,0,2531,2575,44,FALSE,FALSE,FALSE,FALSE,FALSE,16
-7,"00:55:23","42:55","Radio chaser noise 📼","Extended version that is on the white cassette.",23,55,0,3323,55,42,0,2575,2626,51,FALSE,FALSE,FALSE,TRUE,FALSE,17
-7,"00:55:23","43:46","Movie dialogue (7-18)","Verses from the Bible - 1 Corinthians 13:2-3
-Thanks for the ID, u/blakandblue!",23,55,0,3323,46,43,0,2626,2642,16,FALSE,FALSE,FALSE,FALSE,FALSE,18
-7,"00:55:23","44:02","Unreleased full band jam 7-8, 'Radiohead funk' with eventual Thom vocals (7-19)","Continuation of 42:10 w/o vocals? What is this? Vocals enter @ 50:12 w/ lyrics NEEDS INVESTIGATION",23,55,0,3323,2,44,0,2642,5,-2637,FALSE,FALSE,FALSE,FALSE,FALSE,19
-8,"00:57:59","0:05","Unreleased Thom solo (Acoustic instrumental) 8-1, (8-1) 🌚","Some kind of open or low drop tuning",59,57,0,3479,5,0,0,5,278,273,TRUE,FALSE,FALSE,FALSE,FALSE,1
-8,"00:57:59","4:38","Unreleased Thom solo (Acoustic) 8-2, 'You Want It All,' (8-2) 🌚","“You want it all”",59,57,0,3479,38,4,0,278,434,156,TRUE,FALSE,FALSE,FALSE,FALSE,2
-8,"00:57:59","7:14","Unreleased Thom solo (Acoustic) 8-3, 'Send Me Away' (8-3) 🌚","“Send me away”",59,57,0,3479,14,7,0,434,561,127,TRUE,FALSE,FALSE,FALSE,FALSE,3
-8,"00:57:59","9:21","Unreleased Thom solo (Acoustic) 8-4, (8-4) 🌚",NA,59,57,0,3479,21,9,0,561,702,141,TRUE,FALSE,FALSE,FALSE,FALSE,4
-8,"00:57:59","11:42","Karma Police (Early Live Soundboard with Alt. Chorus Lyrics) (8-5)","Soundboard. “This is what you’ll get when you fuck with us”",59,57,0,3479,42,11,0,702,930,228,FALSE,FALSE,FALSE,FALSE,FALSE,5
-8,"00:57:59","15:30","Paranoid Android (Early Live Soundboard, Excerpted on OKNOTOK), 8-1 (8-6)","Soundboard. Early ver. Same show as above. Has “rain down” but no “that’s it sir”. Extended outro from oknotok tape side 2.",59,57,0,3479,30,15,0,930,1356,426,FALSE,FALSE,FALSE,FALSE,FALSE,6
-8,"00:57:59","22:36","I Promise (Early Live Soundboard) (8-7)","Soundboard. Same show.",59,57,0,3479,36,22,0,1356,1588,232,FALSE,FALSE,FALSE,FALSE,FALSE,7
-8,"00:57:59","26:28","Let Down (Early Live Soundboard, Acoustic Intro, Organ) (8-8)","Early. Same show? Acoustic intro, vocals start when drums come in. Organ ending. Repeats 2nd verse.",59,57,0,3479,28,26,0,1588,1883,295,FALSE,FALSE,FALSE,FALSE,FALSE,8
-8,"00:57:59","31:23","Climbing Up The Walls (Early Live Soundboard), 8-1 (8-9)","Early version. Same show?",59,57,0,3479,23,31,0,1883,2134,251,FALSE,FALSE,FALSE,FALSE,FALSE,9
-8,"00:57:59","35:34","No Surprises (Early Live Soundboard) (8-10)",NA,59,57,0,3479,34,35,0,2134,2354,220,FALSE,FALSE,FALSE,FALSE,FALSE,10
-8,"00:57:59","39:14","I Promise (Early Live Soundboard) (8-11)",NA,59,57,0,3479,14,39,0,2354,2588,234,FALSE,FALSE,FALSE,FALSE,FALSE,11
-8,"00:57:59","43:08","Electioneering (Early Live Soundboard) (8-12)",NA,59,57,0,3479,8,43,0,2588,2789,201,FALSE,FALSE,FALSE,FALSE,FALSE,12
-8,"00:57:59","46:29","Paranoid Android (Early Live Soundboard with Organ and Extended Outro) (8-13)","Another ‘96 version w/ organ. Extended outro.",59,57,0,3479,29,46,0,2789,3190,401,FALSE,FALSE,FALSE,FALSE,FALSE,13
-8,"00:57:59","53:10","Theremin-like synthesizer and misc. noises (8-14)",NA,59,57,0,3479,10,53,0,3190,3235,45,FALSE,FALSE,FALSE,FALSE,FALSE,14
-8,"00:57:59","53:55","Climbing Up The Walls (Early Live Soundboard), 8-2 (8-15)",NA,59,57,0,3479,55,53,0,3235,10,-3225,FALSE,FALSE,FALSE,FALSE,FALSE,15
-9,"00:53:33","0:10","Unreleased Ambient Piano Song (9-1)","There's some chatter in the background of this, it could be thom testing stuff.",33,53,0,3213,10,0,0,10,160,150,FALSE,FALSE,FALSE,FALSE,FALSE,1
-9,"00:53:33","2:40","Unreleased Full Band Song ‘Walk Down’ (9-2) ✏️","Fan name by spnii_
-Unreleased full band song. Starts off acoustically, then into full band. Hard to decipher all the lyrics.",33,53,0,3213,40,2,0,160,451,291,FALSE,FALSE,FALSE,FALSE,TRUE,2
-9,"00:53:33","7:31","Let Down (9-3)","Very rough early rehearsal.
-Early/alt lyrics.",33,53,0,3213,31,7,0,451,778,327,FALSE,FALSE,FALSE,FALSE,FALSE,3
-9,"00:53:33","12:58","Karma Police (9-4)","Early rough rehearsal. Different drums, no guitars, more bass, different lyrics.",33,53,0,3213,58,12,0,778,904,126,FALSE,FALSE,FALSE,FALSE,FALSE,4
-9,"00:53:33","15:04","Karma Police (9-5)","Same rehearsal, more distortion on bass and guitars. Sounds more rock. Instrumental after first chorus.",33,53,0,3213,4,15,0,904,1052,148,FALSE,FALSE,FALSE,FALSE,FALSE,5
-9,"00:53:33","17:32","Last Flowers (9-6)","Very rough. More band oriented. Different lyrics, but same melody and key. Jonny is also doing weird things to his guitar.",33,53,0,3213,32,17,0,1052,1241,189,FALSE,FALSE,FALSE,FALSE,FALSE,6
-9,"00:53:33","20:41","Unreleased full band song 'Decided, You Don't Try' (9-7)","Most likely also a rehearsal. Audio tears alot. Same as 7-5. Probably a second take.",33,53,0,3213,41,20,0,1241,1473,232,FALSE,FALSE,FALSE,FALSE,FALSE,7
-9,"00:53:33","24:33","Let Down (10 Minute Rehearsal) (9-8)","Mostly guitars, different arrangement. Possibly the band learning how to play it live due to Thom once saying its “too complicated” to play live. Jonny switches to organ later on.",33,53,0,3213,33,24,0,1473,2123,650,FALSE,FALSE,FALSE,FALSE,FALSE,8
-9,"00:53:33","35:23","Life in a Glasshouse (9-9)","Very different from the finished version, sounds like a rehearsal, but has the same melody, jonny is killing it on the organ.",33,53,0,3213,23,35,0,2123,2278,155,FALSE,FALSE,FALSE,FALSE,FALSE,9
-9,"00:53:33","37:58","Life in a Glasshouse (9-10) 🌚","Thom acoustic. Different chords, lyrics, and slightly different vocal melody. The energy in this one is great.",33,53,0,3213,58,37,0,2278,2442,164,TRUE,FALSE,FALSE,FALSE,FALSE,10
-9,"00:53:33","40:42","Fitter Happier (9-11) 📼","Glitching noises and piano. No text-to-speech. On OKNOTOK cassette as well.",33,53,0,3213,42,40,0,2442,2602,160,FALSE,FALSE,FALSE,TRUE,FALSE,11
-9,"00:53:33","43:22","A Reminder (9-12) 🌚","Thom solo acoustic. Low quality recording.",33,53,0,3213,22,43,0,2602,2813,211,TRUE,FALSE,FALSE,FALSE,FALSE,12
-9,"00:53:33","46:53","Unreleased Thom Solo (Acoustic) ‘You’re The One’ (9-13) 🌚","Fairly sloppy and raw rough recording. Droney guitar tuning and catchy riff. Hook contains lyric “You’re the one”.",33,53,0,3213,53,46,0,2813,3061,248,TRUE,FALSE,FALSE,FALSE,FALSE,13
-9,"00:53:33","51:01","A Reminder (9-14) 🌚","Thom solo acoustic recording. Vocals are very prominent. Same lyrics as studio version.",33,53,0,3213,1,51,0,3061,7,-3054,TRUE,FALSE,FALSE,FALSE,FALSE,14
-10,"00:58:23","0:07","Last Flowers (Early Rehearsal, Rock Version), Take 1 (10-1)","Different lyrics, more band structured, rock & roll sound",23,58,0,3503,7,0,0,7,232,225,FALSE,FALSE,FALSE,FALSE,FALSE,1
-10,"00:58:23","3:52","Last Flowers (Early Rehearsal, Rock Version), Take 2 (10-2)","Different rehearsal? Includes intro and effects",23,58,0,3503,52,3,0,232,336,104,FALSE,FALSE,FALSE,FALSE,FALSE,2
-10,"00:58:23","5:36","True Love Waits (Early Rehearsal, Instrumental Full Band Version) (10-3)","A jam, starts midway",23,58,0,3503,36,5,0,336,486,150,FALSE,FALSE,FALSE,FALSE,FALSE,3
-10,"00:58:23","8:06","True Love Waits (Early Rehearsal, Alt. Arrangement) (10-4)","Stops midway",23,58,0,3503,6,8,0,486,605,119,FALSE,FALSE,FALSE,FALSE,FALSE,4
-10,"00:58:23","10:05","The National Anthem (OKNOTOK Demo, aka 'Everyone') (10-5) 📼","4-track demo, The National Anthem, same one as the cassette tape. 'Everyone' was the working title",23,58,0,3503,5,10,0,605,793,188,FALSE,FALSE,FALSE,TRUE,FALSE,5
-10,"00:58:23","13:13","The Bends (4 Track Demo) (10-6)","4-track demo, this was already released at some point in 1996",23,58,0,3503,13,13,0,793,1082,289,FALSE,FALSE,FALSE,FALSE,FALSE,6
-10,"00:58:23","18:02","Unreleased Thom solo with acoustic guitar drum machine, 10-1 'I Don't Want To Hurt You' (10-7) 🌚","Most likely from the same 4-track demo, could also be on the cassette tape.",23,58,0,3503,2,18,0,1082,1308,226,TRUE,FALSE,FALSE,FALSE,FALSE,7
-10,"00:58:23","21:48","Let Down (Early Rehearsal, Alt. Arrangement with Acoustic Guitars) (10-8)","A more acoustic arrangement with no drums, different lyrics, also the gain is too fucking high",23,58,0,3503,48,21,0,1308,1646,338,FALSE,FALSE,FALSE,FALSE,FALSE,8
-10,"00:58:23","27:26","Airbag (Early Rehearsal, Instrumental) (10-9)","Live demo recording, slightly seeks and skips, also jamming at the end",23,58,0,3503,26,27,0,1646,1769,123,FALSE,FALSE,FALSE,FALSE,FALSE,9
-10,"00:58:23","29:29","Airbag (Early Rehearsals, Instrumental, Prominent Bass) (10-10)","Jamming, features Colin’s bass playing isolated at some point",23,58,0,3503,29,29,0,1769,1832,63,FALSE,FALSE,FALSE,FALSE,FALSE,10
-10,"00:58:23","30:32","Unreleased Thom solo (Acoustic) 10-2, 'Don't Stop,' Take 1 (10-11 🌚","Thom on guitar",23,58,0,3503,32,30,0,1832,2079,247,TRUE,FALSE,FALSE,FALSE,FALSE,11
-10,"00:58:23","34:39","Unreleased Thom solo (Acoustic) 10-2, 'Don't Stop,' Take 2 (10-12) 🌚","Another take of the same song
+1,1:10:47,0:00,Poison (Early Exit Music For A Film / Life In A Glass House) [Thom solo] 🌚,"Though it resembles both Exit Music and LIAGH, it is titled as neither of them.",47,10,1,4247,0,0,0,0,99,99,TRUE,FALSE,FALSE,FALSE,FALSE,1
+1,1:10:47,1:39,I Promise 1-1 (Portland) [soundcheck - 25 March 1996],“I won’t fool around no more…”,47,10,1,4247,39,1,0,99,334,235,FALSE,FALSE,FALSE,FALSE,FALSE,2
+1,1:10:47,5:34,Attenzione! (Portland) [soundcheck - 25 March 1996],Full band,47,10,1,4247,34,5,0,334,636,302,FALSE,FALSE,FALSE,FALSE,FALSE,3
+1,1:10:47,10:36,[tape blip - Electioneering + Attenzione! (Portland)] [duplicate],,47,10,1,4247,36,10,0,636,654,18,FALSE,FALSE,FALSE,FALSE,FALSE,4
+1,1:10:47,10:54,Electioneering 1-1,Early version,47,10,1,4247,54,10,0,654,785,131,FALSE,FALSE,FALSE,FALSE,FALSE,5
+1,1:10:47,13:05,Lift 1-1 (Toronto) [live - 6 April 1996],Early version,47,10,1,4247,5,13,0,785,939,154,FALSE,FALSE,FALSE,FALSE,FALSE,6
+1,1:10:47,15:39,True Love Waits ⭐🤤,Features a full band,47,10,1,4247,39,15,0,939,1332,393,FALSE,TRUE,TRUE,FALSE,FALSE,7
+1,1:10:47,22:12,Not For Sale 🌚,"“Little by little falls away…”
+Mistaken for an early version of Little by Little during the leak",47,10,1,4247,12,22,0,1332,1404,72,TRUE,FALSE,FALSE,FALSE,FALSE,8
+1,1:10:47,23:24,Film A [found sound - Yellow Panic from 3 Days Of The Condor],Snippet taken from a film,47,10,1,4247,24,23,0,1404,1451,47,FALSE,FALSE,FALSE,FALSE,FALSE,9
+1,1:10:47,24:11,Lift 1-2 (San Francisco) [live - 27 March 1996],First live performance!,47,10,1,4247,11,24,0,1451,1694,243,FALSE,FALSE,FALSE,FALSE,FALSE,10
+1,1:10:47,28:14,Electioneering 1-2 (San Francisco) [live - 27 March 1996],,47,10,1,4247,14,28,0,1694,1931,237,FALSE,FALSE,FALSE,FALSE,FALSE,11
+1,1:10:47,32:11,I Promise 1-2 (San Francisco) [live - 27 March 1996],,47,10,1,4247,11,32,0,1931,2180,249,FALSE,FALSE,FALSE,FALSE,FALSE,12
+1,1:10:47,36:20,Vacancies [Thom solo] 🌚,Solo Thom on acoustic,47,10,1,4247,20,36,0,2180,2238,58,TRUE,FALSE,FALSE,FALSE,FALSE,13
+1,1:10:47,37:18,$alty [Thom solo] 🌚,,47,10,1,4247,18,37,0,2238,2279,41,TRUE,FALSE,FALSE,FALSE,FALSE,14
+1,1:10:47,37:59,Airbag 1-1 (Minneapolis acoustic) [soundcheck - 3 April 1996],Early version,47,10,1,4247,59,37,0,2279,2588,309,FALSE,FALSE,FALSE,FALSE,FALSE,15
+1,1:10:47,43:08,Airbag 1-2 (Toronto) [soundcheck - 6 April 1996],This version has a long reverb-y intro,47,10,1,4247,8,43,0,2588,2898,310,FALSE,FALSE,FALSE,FALSE,FALSE,16
+1,1:10:47,48:18,I Promise 1-3 (Minneapolis) [live - 3 April 1996],,47,10,1,4247,18,48,0,2898,3141,243,FALSE,FALSE,FALSE,FALSE,FALSE,17
+1,1:10:47,52:21,Lifesaver [Thom solo] 🌚,,47,10,1,4247,21,52,0,3141,3191,50,TRUE,FALSE,FALSE,FALSE,FALSE,18
+1,1:10:47,53:11,I Promise 1-4 (Toronto) [live - 6 April 1996],,47,10,1,4247,11,53,0,3191,3434,243,FALSE,FALSE,FALSE,FALSE,FALSE,19
+1,1:10:47,57:14,Electioneering 1-3 (Toronto) [live - 6 April 1996],With acoustic guitar & harmonies,47,10,1,4247,14,57,0,3434,3648,214,FALSE,FALSE,FALSE,FALSE,FALSE,20
+1,1:10:47,1:00:48,Paranoid Android,Early version; different lyrics,47,10,1,4247,48,0,1,3648,3928,280,FALSE,FALSE,FALSE,FALSE,FALSE,21
+1,1:10:47,1:05:28,Airbag 1-3,"Clip starts midway, sounds like the complete version",47,10,1,4247,28,5,1,3928,4053,125,FALSE,FALSE,FALSE,FALSE,FALSE,22
+1,1:10:47,1:07:33,Electioneering 1-4,Ed/Jonny harmonizing? Cuts off early,47,10,1,4247,33,7,1,4053,4247,194,FALSE,FALSE,FALSE,FALSE,FALSE,23
+2,1:01:27,0:00,No Surprises Please (Lyon) [soundcheck - 17 April 1996] 📼,Early version; already heard in the cassette,27,1,1,3687,0,0,0,0,174,174,FALSE,FALSE,FALSE,TRUE,FALSE,1
+2,1:01:27,2:54,Risk Of Suffocation [Thom solo] 🌚,Acoustic. Song cuts off midway. “If I get my head out of this…”,27,1,1,3687,54,2,0,174,344,170,TRUE,FALSE,FALSE,FALSE,FALSE,2
+2,1:01:27,5:44,Girl Club 2-1 [Thom solo] 🌚,Acoustic. Groovy guitar riff.,27,1,1,3687,44,5,0,344,478,134,TRUE,FALSE,FALSE,FALSE,FALSE,3
+2,1:01:27,7:58,Girl Club 2-2 [Thom solo] 🌚,,27,1,1,3687,58,7,0,478,518,40,TRUE,FALSE,FALSE,FALSE,FALSE,4
+2,1:01:27,8:38,Ride A Pony [Thom solo] 🌚,,27,1,1,3687,38,8,0,518,736,218,TRUE,FALSE,FALSE,FALSE,FALSE,5
+2,1:01:27,12:16,(Chateau Birds) [found sound],,27,1,1,3687,16,12,0,736,785,49,FALSE,FALSE,FALSE,FALSE,FALSE,6
+2,1:01:27,13:05,Umbilical [Thom solo] 🌚,,27,1,1,3687,5,13,0,785,947,162,TRUE,FALSE,FALSE,FALSE,FALSE,7
+2,1:01:27,15:47,Poison Lake (Early Exit Music For a Film) [Thom solo] 🌚,Very similar to Exit Music - Poison or Poison Lake might have been its original title. This was a snippet included in the previews before all 18 discs leaked,27,1,1,3687,47,15,0,947,1162,215,TRUE,FALSE,FALSE,FALSE,FALSE,8
+2,1:01:27,19:22,Get Together #2 [Thom solo] 🌚,,27,1,1,3687,22,19,0,1162,1254,92,TRUE,FALSE,FALSE,FALSE,FALSE,9
+2,1:01:27,20:54,Get Together [Thom solo] 🌚,,27,1,1,3687,54,20,0,1254,1288,34,TRUE,FALSE,FALSE,FALSE,FALSE,10
+2,1:01:27,21:28,(Prague Train) [found sound],Ladies chattering in a foreign language & sounds of public transportation. These sounds are heard in the intro of A Reminder.,27,1,1,3687,28,21,0,1288,1521,233,FALSE,FALSE,FALSE,FALSE,FALSE,11
+2,1:01:27,25:21,(Bus Home) [found sound],,27,1,1,3687,21,25,0,1521,1561,40,FALSE,FALSE,FALSE,FALSE,FALSE,12
+2,1:01:27,26:01,Annoying Neighbors 2-1 [Thom solo],fragment,27,1,1,3687,1,26,0,1561,1586,25,FALSE,FALSE,FALSE,FALSE,FALSE,13
+2,1:01:27,26:26,Annoying Neighbors 2-2 [Thom solo],Fragment; 2nd take,27,1,1,3687,26,26,0,1586,1597,11,FALSE,FALSE,FALSE,FALSE,FALSE,14
+2,1:01:27,26:37,Annoying Neighbors 2-3 [Thom solo],3rd take,27,1,1,3687,37,26,0,1597,1776,179,FALSE,FALSE,FALSE,FALSE,FALSE,15
+2,1:01:27,29:36,Motion Picture Soundtrack 2-1 🤤,Early rehearsal; sounds pretty Bends-y,27,1,1,3687,36,29,0,1776,2085,309,FALSE,TRUE,FALSE,FALSE,FALSE,16
+2,1:01:27,34:45,Amazing Drums For Exit Music 2-1,Similar chord progression to the album Exit Music,27,1,1,3687,45,34,0,2085,2137,52,FALSE,FALSE,FALSE,FALSE,FALSE,17
+2,1:01:27,35:37,Amazing Drums For Exit Music 2-2,,27,1,1,3687,37,35,0,2137,2158,21,FALSE,FALSE,FALSE,FALSE,FALSE,18
+2,1:01:27,35:58,Amazing Drums For Exit Music 2-3,,27,1,1,3687,58,35,0,2158,2206,48,FALSE,FALSE,FALSE,FALSE,FALSE,19
+2,1:01:27,36:46,unknown song (full-band instrumental),Has some vocals to an unknown song. Drums sound similar to Pearly,27,1,1,3687,46,36,0,2206,2245,39,FALSE,FALSE,FALSE,FALSE,FALSE,20
+2,1:01:27,37:25,Let Down (Early Rehearsal) (2-19),Early rehearsal; some jamming at the end,27,1,1,3687,25,37,0,2245,2543,298,FALSE,FALSE,FALSE,FALSE,FALSE,21
+2,1:01:27,42:23,Motion Picture Soundtrack 2-2,Early rehearsal,27,1,1,3687,23,42,0,2543,2838,295,FALSE,FALSE,FALSE,FALSE,FALSE,22
+2,1:01:27,47:18,Airbag,Early Rehearsal with A false start at the beginning,27,1,1,3687,18,47,0,2838,3141,303,FALSE,FALSE,FALSE,FALSE,FALSE,23
+2,1:01:27,52:21,My New Clothes 2-1 🤤,"Originally fan named by belargu as Hurts To Walk (My Funky Cloak) ✏️
+This is the goofiest shit I’ve ever heard lol I LOVE it",27,1,1,3687,21,52,0,3141,3374,233,FALSE,TRUE,FALSE,FALSE,FALSE,24
+2,1:01:27,56:14,My New Clothes 2-2 [fragment],Seems to be take 2 of the previous song,27,1,1,3687,14,56,0,3374,3391,17,FALSE,FALSE,FALSE,FALSE,FALSE,25
+2,1:01:27,56:31,My New Clothes 2-3,,27,1,1,3687,31,56,0,3391,3594,203,FALSE,FALSE,FALSE,FALSE,FALSE,26
+2,1:01:27,59:54,Attenzione! (Early Attention) 2-1,,27,1,1,3687,54,59,0,3594,3622,28,FALSE,FALSE,FALSE,FALSE,FALSE,27
+2,1:01:27,1:00:22,Attenzione! (Early Attention) 2-2,,27,1,1,3687,22,0,1,3622,3687,65,FALSE,FALSE,FALSE,FALSE,FALSE,28
+3,1:05:08,0:00,I Promise 3-1 (NY) [live - 12 April 1996],Cut intro,8,5,1,3908,0,0,0,0,70,70,FALSE,FALSE,FALSE,FALSE,FALSE,1
+3,1:05:08,1:10,Motion Picture Soundtrack (Rockville) [Thom solo - 10 April 1996],"Solo Thom on electric guitar
+According to redditor /u/EsotericCD, this is from the 4/10/96 “Just Passin’ Thru” radio session in Rockville, MD, but is a “FAR FAR better sounding version of it than the off-air recording we used to have.” Thanks for the ID!",8,5,1,3908,10,1,0,70,281,211,FALSE,FALSE,FALSE,FALSE,FALSE,2
+3,1:05:08,4:41,[tape blip - I Promise (San Francisco)] [duplicate],,8,5,1,3908,41,4,0,281,286,5,FALSE,FALSE,FALSE,FALSE,FALSE,3
+3,1:05:08,4:46,I Promise 3-2 (San Francisco) [live - 27 March 1996] [duplicate],"First ever live performance, announcement at beginning. Duplicate, Thom Intro.",8,5,1,3908,46,4,0,286,537,251,FALSE,FALSE,FALSE,FALSE,FALSE,4
+3,1:05:08,8:57,Mahler's Double Basses [found sound],Snippet of something else,8,5,1,3908,57,8,0,537,541,4,FALSE,FALSE,FALSE,FALSE,FALSE,5
+3,1:05:08,9:01,Nude,Full band version. Different from the cassette version. Pretty raunchy lyrics...,8,5,1,3908,1,9,0,541,784,243,FALSE,FALSE,FALSE,FALSE,FALSE,6
+3,1:05:08,13:04,Monk Noise [found sound],A part of this segment has seemingly been removed,8,5,1,3908,4,13,0,784,822,38,FALSE,FALSE,FALSE,FALSE,FALSE,7
+3,1:05:08,13:42,Moog,A synthesizer solo,8,5,1,3908,42,13,0,822,896,74,FALSE,FALSE,FALSE,FALSE,FALSE,8
+3,1:05:08,14:56,S3000,This is a snippet from Joe Henderson - El Barrio.,8,5,1,3908,56,14,0,896,942,46,FALSE,FALSE,FALSE,FALSE,FALSE,9
+3,1:05:08,15:42,Soft Pain 3-1,Instrumental stem of piano & other noises,8,5,1,3908,42,15,0,942,1037,95,FALSE,FALSE,FALSE,FALSE,FALSE,10
+3,1:05:08,17:17,Soft Pain 3-2,Similar to above,8,5,1,3908,17,17,0,1037,1122,85,FALSE,FALSE,FALSE,FALSE,FALSE,11
+3,1:05:08,18:42,Soft Pain 3-3,"Similar to above, now with a drum loop and more synths",8,5,1,3908,42,18,0,1122,1344,222,FALSE,FALSE,FALSE,FALSE,FALSE,12
+3,1:05:08,22:24,Thomas Pynchon,Soothing instrumental,8,5,1,3908,24,22,0,1344,1567,223,FALSE,FALSE,FALSE,FALSE,FALSE,13
+3,1:05:08,26:07,Maybe [Thom solo]🌚,,8,5,1,3908,7,26,0,1567,1724,157,TRUE,FALSE,FALSE,FALSE,FALSE,14
+3,1:05:08,28:44,Soft Pain VOX 3-4 [Thom solo]🌚,"Combined with the Soft Pain instrumentals above, it forms a more tangible song. u/k0stil made a mix of it here.",8,5,1,3908,44,28,0,1724,1877,153,TRUE,FALSE,FALSE,FALSE,FALSE,15
+3,1:05:08,31:17,Soft Pain 3-5,"Similar to 3-3, but with acoustic guitar panned to the left",8,5,1,3908,17,31,0,1877,2120,243,FALSE,FALSE,FALSE,FALSE,FALSE,16
+3,1:05:08,35:20,Oranges [Thom solo] 🌚,,8,5,1,3908,20,35,0,2120,2297,177,TRUE,FALSE,FALSE,FALSE,FALSE,17
+3,1:05:08,38:17,$ Island [Thom solo]) 🌚,,8,5,1,3908,17,38,0,2297,2557,260,TRUE,FALSE,FALSE,FALSE,FALSE,18
+3,1:05:08,42:37,Poison 3-1 [Thom solo ] 🌚,"Very early version of Exit Music. Thom solo, alternate arrangement, rhythm and lyrics.",8,5,1,3908,37,42,0,2557,2784,227,TRUE,FALSE,FALSE,FALSE,FALSE,19
+3,1:05:08,46:24,Poison 3-2 [Thom solo ] 🌚,,8,5,1,3908,24,46,0,2784,2820,36,TRUE,FALSE,FALSE,FALSE,FALSE,20
+3,1:05:08,47:00,7/8 Session,"Very early rehearsal of Paranoid Android, & only a section
+(before “you don’t remember, why don’t you remember my name?” excerpt live) Fragmented Instrumental.",8,5,1,3908,0,47,0,2820,2912,92,FALSE,FALSE,FALSE,FALSE,FALSE,21
+3,1:05:08,48:32,No Surprises,Early Soundcheck,8,5,1,3908,32,48,0,2912,3115,203,FALSE,FALSE,FALSE,FALSE,FALSE,22
+3,1:05:08,51:55,Messy Jams,"Originally fan named by the Bumstickler as Thom’s Screechy Song ✏️
+Screechy Sonic Youth-like Guitar",8,5,1,3908,55,51,0,3115,3409,294,FALSE,FALSE,FALSE,FALSE,FALSE,23
+3,1:05:08,56:49,Soft Pain 3-6,e v e n   m o r e    l a y e r s,8,5,1,3908,49,56,0,3409,3734,325,FALSE,FALSE,FALSE,FALSE,FALSE,24
+3,1:05:08,1:02:14,unknown song (lyric - 'I don't get it') [Thom solo] 🌚,,8,5,1,3908,14,2,1,3734,3908,174,TRUE,FALSE,FALSE,FALSE,FALSE,25
+4,0:57:21,0:00,Organ Intro,,21,57,0,3441,0,0,0,0,92,92,FALSE,FALSE,FALSE,FALSE,FALSE,1
+4,0:57:21,1:32,No Surprises Please,Crazy outro,21,57,0,3441,32,1,0,92,349,257,FALSE,FALSE,FALSE,FALSE,FALSE,2
+4,0:57:21,5:49,[tape blip - Bullet Proof.. I Wish I Was],3 second blip,21,57,0,3441,49,5,0,349,351,2,FALSE,FALSE,FALSE,FALSE,FALSE,3
+4,0:57:21,5:51,True Love Waits (prog),"Early instrumental with drum machine, acoustic guitar, and bg synth.",21,57,0,3441,51,5,0,351,657,306,FALSE,FALSE,FALSE,FALSE,FALSE,4
+4,0:57:21,10:57,Soft Pain 4-1,"Very staticy midway, ends with drum solo.",21,57,0,3441,57,10,0,657,872,215,FALSE,FALSE,FALSE,FALSE,FALSE,5
+4,0:57:21,14:32,Soft Pain 4-2,Both instrumentals on this disc seem more aggressive than the others heard previously,21,57,0,3441,32,14,0,872,1093,221,FALSE,FALSE,FALSE,FALSE,FALSE,6
+4,0:57:21,18:13,Paranoid Android M8 4-1 to 4-4,"Starts at “You don’t remember... “ section, Thom stops band halfway through to talk about changes. Includes multiple takes & jamming.",21,57,0,3441,13,18,0,1093,1635,542,FALSE,FALSE,FALSE,FALSE,FALSE,7
+4,0:57:21,27:15,Motion Picture Soundtrack 4-1,Take One. Fairly slow paced.,21,57,0,3441,15,27,0,1635,1955,320,FALSE,FALSE,FALSE,FALSE,FALSE,8
+4,0:57:21,32:35,Motion Picture Soundtrack 4-2,Second take. Also fairly slow paced.,21,57,0,3441,35,32,0,1955,2279,324,FALSE,FALSE,FALSE,FALSE,FALSE,9
+4,0:57:21,37:59,Airbag 4-1,"Early full band version. Different intro and very rough, longer outro",21,57,0,3441,59,37,0,2279,2573,294,FALSE,FALSE,FALSE,FALSE,FALSE,10
+4,0:57:21,42:53,Airbag 4-2,,21,57,0,3441,53,42,0,2573,2879,306,FALSE,FALSE,FALSE,FALSE,FALSE,11
+4,0:57:21,47:59,Tourists 4-1,"Early title for The Tourist.
+Contains a different melody than what is on the album.",21,57,0,3441,59,47,0,2879,3055,176,FALSE,FALSE,FALSE,FALSE,FALSE,12
+4,0:57:21,50:55,Tourists 4-2,,21,57,0,3441,55,50,0,3055,3122,67,FALSE,FALSE,FALSE,FALSE,FALSE,13
+4,0:57:21,52:02,Tourists 4-3,,21,57,0,3441,2,52,0,3122,3195,73,FALSE,FALSE,FALSE,FALSE,FALSE,14
+4,0:57:21,53:15,Silicon Valley,Early demo of Palo Alto. with slightly different lyrics. Chorus has slightly different melody,21,57,0,3441,15,53,0,3195,3441,246,FALSE,FALSE,FALSE,FALSE,FALSE,15
+5,0:57:02,0:00,[drums + band chatter],Unstructured jam; goofing around,2,57,0,3422,0,0,0,0,66,66,FALSE,FALSE,FALSE,FALSE,FALSE,1
+5,0:57:02,1:06,Paranoid Android Outro 5-1,Practice run from “rain down” section,2,57,0,3422,6,1,0,66,336,270,FALSE,FALSE,FALSE,FALSE,FALSE,2
+5,0:57:02,5:36,"Paranoid Android 5-2 (Long Version, Full Length Rehearsal) ⭐",8 minute early version w/ outro jam,2,57,0,3422,36,5,0,336,824,488,FALSE,FALSE,TRUE,FALSE,FALSE,3
+5,0:57:02,13:44,Jam,Jam.,2,57,0,3422,44,13,0,824,1006,182,FALSE,FALSE,FALSE,FALSE,FALSE,4
+5,0:57:02,16:46,Attenzione! 5-1 [fragment],Another snippet of “Attention”,2,57,0,3422,46,16,0,1006,1038,32,FALSE,FALSE,FALSE,FALSE,FALSE,5
+5,0:57:02,17:18,Attenzione! 5-2,,2,57,0,3422,18,17,0,1038,1071,33,FALSE,FALSE,FALSE,FALSE,FALSE,6
+5,0:57:02,17:51,Touchies + Feelies 5-1 [fragment],Gets fast forwarded,2,57,0,3422,51,17,0,1071,1081,10,FALSE,FALSE,FALSE,FALSE,FALSE,7
+5,0:57:02,18:01,Touchies + Feelies 5-2,Has vocals at one point,2,57,0,3422,1,18,0,1081,1553,472,FALSE,FALSE,FALSE,FALSE,FALSE,8
+5,0:57:02,25:53,Leave Me Alone,Has vocals. “When I Get Bored Give Me One of Those”,2,57,0,3422,53,25,0,1553,1809,256,FALSE,FALSE,FALSE,FALSE,FALSE,9
+5,0:57:02,30:09,No Surprises Please 5-1,"Early version, full band",2,57,0,3422,9,30,0,1809,2037,228,FALSE,FALSE,FALSE,FALSE,FALSE,10
+5,0:57:02,33:57,No Surprises 5-2,"Early version, full band",2,57,0,3422,57,33,0,2037,2262,225,FALSE,FALSE,FALSE,FALSE,FALSE,11
+5,0:57:02,37:42,Attenzione! 5-3,Unreleased full band song,2,57,0,3422,42,37,0,2262,2293,31,FALSE,FALSE,FALSE,FALSE,FALSE,12
+5,0:57:02,38:13,Attenzione! 5-4,,2,57,0,3422,13,38,0,2293,2410,117,FALSE,FALSE,FALSE,FALSE,FALSE,13
+5,0:57:02,40:10,Attenzione! 5-5,,2,57,0,3422,10,40,0,2410,2561,151,FALSE,FALSE,FALSE,FALSE,FALSE,14
+5,0:57:02,42:41,"'We Have Registered', ‘Good Morning’,  ‘Fax’, ‘Bell’, ‘Squeal’ [found sounds]",Little sound effects that have been individually named by Thom,2,57,0,3422,41,42,0,2561,2636,75,FALSE,FALSE,FALSE,FALSE,FALSE,15
+5,0:57:02,43:56,Lights Down [Thom solo]🌚,Acoustic. Cheap mic.,2,57,0,3422,56,43,0,2636,2735,99,TRUE,FALSE,FALSE,FALSE,FALSE,16
+5,0:57:02,45:35,Boggle Eyes [Thom solo] 🌚,,2,57,0,3422,35,45,0,2735,2808,73,TRUE,FALSE,FALSE,FALSE,FALSE,17
+5,0:57:02,46:48,'Silly Voices' [found sound],,2,57,0,3422,48,46,0,2808,2817,9,FALSE,FALSE,FALSE,FALSE,FALSE,18
+5,0:57:02,46:57,27° [Thom solo] 🌚,“You don’t see the signs”,2,57,0,3422,57,46,0,2817,2910,93,TRUE,FALSE,FALSE,FALSE,FALSE,19
+5,0:57:02,48:30,Chairman Mao [Thom solo] 🌚,,2,57,0,3422,30,48,0,2910,2988,78,TRUE,FALSE,FALSE,FALSE,FALSE,20
+5,0:57:02,49:48,Nude Rough [Thom solo] 🌚,Thom solo acoustic demo (early),2,57,0,3422,48,49,0,2988,3189,201,TRUE,FALSE,FALSE,FALSE,FALSE,21
+5,0:57:02,53:09,'Beauty Voices' [found sound],Lo-fi,2,57,0,3422,9,53,0,3189,3224,35,FALSE,FALSE,FALSE,FALSE,FALSE,22
+5,0:57:02,53:44,Paranoid Android [Thom + Jonny - fragments] 5-3,Early fragment of a Thom/Jonny version,2,57,0,3422,44,53,0,3224,3247,23,FALSE,FALSE,FALSE,FALSE,FALSE,23
+5,0:57:02,54:07,Drum Loop,Lo-fi,2,57,0,3422,7,54,0,3247,3369,122,FALSE,FALSE,FALSE,FALSE,FALSE,24
+5,0:57:02,56:09,Piano Sketch by Jonny 📼,Included in the OKNOTOK cassette,2,57,0,3422,9,56,0,3369,3422,53,FALSE,FALSE,FALSE,TRUE,FALSE,25
+6,0:25:57,0:00,Guitar Loop,Crunchy,57,25,0,1557,0,0,0,0,52,52,FALSE,FALSE,FALSE,FALSE,FALSE,1
+6,0:25:57,0:52,Phil’s Loop,Drummy,57,25,0,1557,52,0,0,52,78,26,FALSE,FALSE,FALSE,FALSE,FALSE,2
+6,0:25:57,1:18,Walls [Thom solo] 🤤🌚,"Acoustic. Thom pls enunciate
+’And If It…’",57,25,0,1557,18,1,0,78,209,131,TRUE,TRUE,FALSE,FALSE,FALSE,3
+6,0:25:57,3:29,Not All Angels Have Wings (Early Last Flowers) [Thom solo] 🤤🌚,"Early version
+“No evaluations, no deliberations”",57,25,0,1557,29,3,0,209,322,113,TRUE,TRUE,FALSE,FALSE,FALSE,4
+6,0:25:57,5:22,Felix The Cat [Thom solo] 🌚,Acoustic. “If I Don’t Seem Him”,57,25,0,1557,22,5,0,322,480,158,TRUE,FALSE,FALSE,FALSE,FALSE,5
+6,0:25:57,8:00,Hollow Tugboat x2 [Thom solo] 🌚,Acoustic. Seems to pick up from the previous song; maybe a retake.,57,25,0,1557,0,8,0,480,636,156,TRUE,FALSE,FALSE,FALSE,FALSE,6
+6,0:25:57,10:36,Not All Angels Have Wings #2 (Early Last Flowers) [Thom solo] 🌚,Thom solo acoustic.,57,25,0,1557,36,10,0,636,858,222,TRUE,FALSE,FALSE,FALSE,FALSE,7
+6,0:25:57,14:18,Life In A Glasshouse [Thom solo] 🌚,Very early version. Contains Tin-can audio.,57,25,0,1557,18,14,0,858,1084,226,TRUE,FALSE,FALSE,FALSE,FALSE,8
+6,0:25:57,18:04,Bubble [Thom solo] 🌚,"Lofi, and Acoustic.",57,25,0,1557,4,18,0,1084,1208,124,TRUE,FALSE,FALSE,FALSE,FALSE,9
+6,0:25:57,20:08,Spokes [Thom solo] 🌚,"Acoustic. Lo-fi. Thom interrupts the song to talk about letters; possibly a retake halfway through. “We Don’t Spend, We Don’t Know.",57,25,0,1557,8,20,0,1208,1428,220,TRUE,FALSE,FALSE,FALSE,FALSE,10
+6,0:25:57,23:48,Snidy [Thom solo] 🌚,,57,25,0,1557,48,23,0,1428,1444,16,TRUE,FALSE,FALSE,FALSE,FALSE,11
+6,0:25:57,24:04,Bee Sting [Thom solo] 🌚,"Lofi, and Acoustic. Also “We Don’t Spend, We Don’t Know”. *Have to double check … the time seems weird on the guy’s new timestamps.",57,25,0,1557,4,24,0,1444,1557,113,TRUE,FALSE,FALSE,FALSE,FALSE,12
+7,0:55:28,0:00,Our Guarantee To You [Thom solo] 🤤🌚,Acoustic. “Leave your comments and reactions here”,28,55,0,3328,0,0,0,0,162,162,TRUE,TRUE,FALSE,FALSE,FALSE,1
+7,0:55:28,2:42,Not All Angels #1-3 (Full Band Last Flowers),Full Band. Drop out or mixing error at 5:52,28,55,0,3328,42,2,0,162,439,277,FALSE,FALSE,FALSE,FALSE,FALSE,2
+7,0:55:28,7:19,Melatonin (Alternate Studio Version) aka Crumar Song,Alternate version or mix,28,55,0,3328,19,7,0,439,568,129,FALSE,FALSE,FALSE,FALSE,FALSE,3
+7,0:55:28,9:28,Julie Got Married [Full band],"“You would do the same, thousand miles, wanted to believe in”",28,55,0,3328,28,9,0,568,701,133,FALSE,FALSE,FALSE,FALSE,FALSE,4
+7,0:55:28,11:41,Ed's French Loop,Might be a song fragment,28,55,0,3328,41,11,0,701,747,46,FALSE,FALSE,FALSE,FALSE,FALSE,5
+7,0:55:28,12:27,August 🤤,With organ and ride cymbal keeping time,28,55,0,3328,27,12,0,747,895,148,FALSE,TRUE,FALSE,FALSE,FALSE,6
+7,0:55:28,14:55,Nigel AMS Delay + AMS Hello 📼 7-4,Both on the cassette.,28,55,0,3328,55,14,0,895,974,79,FALSE,FALSE,FALSE,TRUE,FALSE,7
+7,0:55:28,16:14,EQ Loops/Loop 1-8/Tom Loop,,28,55,0,3328,14,16,0,974,1073,99,FALSE,FALSE,FALSE,FALSE,FALSE,8
+7,0:55:28,17:53,"Karma Police (Early Rehearsal, Electric Guitar, Alt. Lyrics)","Very early, unfinished lyrics. “This is what you get when you fuck with me”",28,55,0,3328,53,17,0,1073,1330,257,FALSE,FALSE,FALSE,FALSE,FALSE,9
+7,0:55:28,22:10,I Need A Job [Full band],"“You won’t try, I wanna go to the edge(?)”",28,55,0,3328,10,22,0,1330,1672,342,FALSE,FALSE,FALSE,FALSE,FALSE,10
+7,0:55:28,27:52,The Cupboard Monster? [Full band],“Psychedelic-ish”,28,55,0,3328,52,27,0,1672,1721,49,FALSE,FALSE,FALSE,FALSE,FALSE,11
+7,0:55:28,28:41,"Airbag Intro (Early Rehearsal, Heavier Rock Guitar Only)","Very early guitar. Slower tempo, rock arrangement intro",28,55,0,3328,41,28,0,1721,1753,32,FALSE,FALSE,FALSE,FALSE,FALSE,12
+7,0:55:28,29:13,Airbag Groove (Early Rehearsal with Jam Intro),"Funky rock jam turns into early Airbag, full band",28,55,0,3328,13,29,0,1753,1817,64,FALSE,FALSE,FALSE,FALSE,FALSE,13
+7,0:55:28,30:17,"Airbag Ace! (Early Rehearsal, Heavier Version) 🤤",Very early attempt #3,28,55,0,3328,17,30,0,1817,2104,287,FALSE,TRUE,FALSE,FALSE,FALSE,14
+7,0:55:28,35:04,Let Down (Early Rehearsal),Early Let Down,28,55,0,3328,4,35,0,2104,2531,427,FALSE,FALSE,FALSE,FALSE,FALSE,15
+7,0:55:28,42:11,I Can’t Control It [Full band],"Almost sounds like Last Flowers. Funky, “Something Got A Hold of Your Mind”.",28,55,0,3328,11,42,0,2531,2575,44,FALSE,FALSE,FALSE,FALSE,FALSE,16
+7,0:55:28,42:55,Radio chaser noise 📼,Extended version that is on the white cassette.,28,55,0,3328,55,42,0,2575,2626,51,FALSE,FALSE,FALSE,TRUE,FALSE,17
+7,0:55:28,43:46,Movie dialogue (7-18),"Verses from the Bible - 1 Corinthians 13:2-3
+Thanks for the ID, u/blakandblue!",28,55,0,3328,46,43,0,2626,2642,16,FALSE,FALSE,FALSE,FALSE,FALSE,18
+7,0:55:28,44:02,Dying Of Boredom [Full band],,28,55,0,3328,2,44,0,2642,3328,686,FALSE,FALSE,FALSE,FALSE,FALSE,19
+8,0:57:03,0:00,Science Helps Build A New India [Thom solo] 🌚,Some kind of open or low drop tuning,3,57,0,3423,0,0,0,0,256,256,TRUE,FALSE,FALSE,FALSE,FALSE,1
+8,0:57:03,4:16,Human Error [Thom solo] 🌚,“You want it all”,3,57,0,3423,16,4,0,256,419,163,TRUE,FALSE,FALSE,FALSE,FALSE,2
+8,0:57:03,06:59,Nervous [Thom solo] 🌚,Acoustic. “Send me away”,3,57,0,3423,59,6,0,419,547,128,TRUE,FALSE,FALSE,FALSE,FALSE,3
+8,0:57:03,9:07,Ground [Thom solo] 🌚,,3,57,0,3423,7,9,0,547,687,140,TRUE,FALSE,FALSE,FALSE,FALSE,4
+8,0:57:03,11:27,"Karma Police (Live, Pittsburgh, 27 Aug 96 with Alt. Chorus Lyrics)",Soundboard. “This is what you’ll get when you fuck with us”,3,57,0,3423,27,11,0,687,915,228,FALSE,FALSE,FALSE,FALSE,FALSE,5
+8,0:57:03,15:15,"Paranoid Android 8-1 (Live, Pittsburgh, 27 Aug 96)",Soundboard. Early ver. Same show as above. Has “rain down” but no “that’s it sir”. Excerpted on OKNOTOK,3,57,0,3423,15,15,0,915,1341,426,FALSE,FALSE,FALSE,FALSE,FALSE,6
+8,0:57:03,22:21,"I Promise 8-1 (Live, Pittsburgh, 27 Aug 96)",Early Soundboard.,3,57,0,3423,21,22,0,1341,1571,230,FALSE,FALSE,FALSE,FALSE,FALSE,7
+8,0:57:03,26:11,"Let Down (Live, Pittsburgh, 27 Aug 96)",Early. Acoustic intro. Organ ending. Repeats 2nd verse.,3,57,0,3423,11,26,0,1571,1867,296,FALSE,FALSE,FALSE,FALSE,FALSE,8
+8,0:57:03,31:07,"Climbing Up The Walls 8-1 (Live, Hershey, 26 Aug 96)","Early version, also soundboard. Same show possibly.",3,57,0,3423,7,31,0,1867,2118,251,FALSE,FALSE,FALSE,FALSE,FALSE,9
+8,0:57:03,35:18,"No Surprises (Live, Hershey, 26 Aug 96)",Early live soundboard recording,3,57,0,3423,18,35,0,2118,2339,221,FALSE,FALSE,FALSE,FALSE,FALSE,10
+8,0:57:03,38:59,"I Promise 8-2 (Live, Hershey, 26 Aug 96)",Early live soundboard recording,3,57,0,3423,59,38,0,2339,2566,227,FALSE,FALSE,FALSE,FALSE,FALSE,11
+8,0:57:03,42:46,"Electioneering (Live, Hershey, 26 Aug 96)",Early live soundboard recording,3,57,0,3423,46,42,0,2566,2773,207,FALSE,FALSE,FALSE,FALSE,FALSE,12
+8,0:57:03,46:13,"Paranoid Android 8-2 (Live, Hershey, 26 Aug 96)",Another early live ‘96 version w/ organ. Extended outro.,3,57,0,3423,13,46,0,2773,3175,402,FALSE,FALSE,FALSE,FALSE,FALSE,13
+8,0:57:03,52:55,Climbing Up The Walls 8-2 (Live),Early live soundboard recording.,3,57,0,3423,55,52,0,3175,3423,248,FALSE,FALSE,FALSE,FALSE,FALSE,14
+9,0:53:37,0:00,Piano 5ths,There's some chatter in the background of this - it could be Thom testing stuff.,37,53,0,3217,0,0,0,0,160,160,FALSE,FALSE,FALSE,FALSE,FALSE,1
+9,0:53:37,2:40,Theme Tune / My Everyday Life [Full band],"Originally fan named by spnii_ as Walk Down ✏️
+Unreleased full band song. Starts off acoustically, then into full band. Hard to decipher all the lyrics.",37,53,0,3217,40,2,0,160,451,291,FALSE,FALSE,FALSE,FALSE,FALSE,2
+9,0:53:37,7:31,Let Down 9-1,"Very rough early rehearsal.
+Early/alt lyrics.",37,53,0,3217,31,7,0,451,778,327,FALSE,FALSE,FALSE,FALSE,FALSE,3
+9,0:53:37,12:58,Karma Police 9-1,"Early rough rehearsal. Different drums, no guitars, more bass, different lyrics.",37,53,0,3217,58,12,0,778,904,126,FALSE,FALSE,FALSE,FALSE,FALSE,4
+9,0:53:37,15:04,Karma Police 9-2,"Same rehearsal, more distortion on bass and guitars. Sounds more rock. Instrumental after first chorus.",37,53,0,3217,4,15,0,904,1052,148,FALSE,FALSE,FALSE,FALSE,FALSE,5
+9,0:53:37,17:32,Hospital 2 (Early Last Flowers),"Very rough. More band oriented. Different lyrics, but same melody and key. Jonny is also doing weird things to his guitar.",37,53,0,3217,32,17,0,1052,1241,189,FALSE,FALSE,FALSE,FALSE,FALSE,6
+9,0:53:37,20:41,The State Disco [Full band],"Most likely also a rehearsal. Audio tears alot. Same as 7-5. Probably a second take. “Decided, You Don’t Try.",37,53,0,3217,41,20,0,1241,1473,232,FALSE,FALSE,FALSE,FALSE,FALSE,7
+9,0:53:37,24:33,Let Down 9-2 (10 Minute Rehearsal),"Mostly guitars, different arrangement. Possibly the band learning how to play it live due to Thom once saying its “too complicated” to play live. Jonny switches to organ later on.",37,53,0,3217,33,24,0,1473,2123,650,FALSE,FALSE,FALSE,FALSE,FALSE,8
+9,0:53:37,35:23,Life in a Glasshouse [Full band],"Very different from the finished version, sounds like a rehearsal, but has the same melody, jonny is killing it on the organ.",37,53,0,3217,23,35,0,2123,2278,155,FALSE,FALSE,FALSE,FALSE,FALSE,9
+9,0:53:37,37:58,Exit Music #2 (Early Life in a Glasshouse) [Thom solo] 🌚,"Thom acoustic. Different chords, lyrics, and slightly different vocal melody. The energy in this one is great.",37,53,0,3217,58,37,0,2278,2442,164,TRUE,FALSE,FALSE,FALSE,FALSE,10
+9,0:53:37,40:42,Piano! Lie down in the middle of the road (Fitter Happier piano) 📼,Glitching noises and piano. No text-to-speech. On OKNOTOK cassette as well.,37,53,0,3217,42,40,0,2442,2602,160,FALSE,FALSE,FALSE,TRUE,FALSE,11
+9,0:53:37,43:22,Play Me This Song 9-1 (Early A Reminder) [Thom solo] 🌚,Thom solo acoustic. Low quality recording.,37,53,0,3217,22,43,0,2602,2808,206,TRUE,FALSE,FALSE,FALSE,FALSE,12
+9,0:53:37,46:48,You’re The One 🌚,Fairly sloppy and raw rough acoustic recording. Droney guitar tuning and catchy riff. Hook contains lyric “You’re the one”.,37,53,0,3217,48,46,0,2808,3047,239,TRUE,FALSE,FALSE,FALSE,FALSE,13
+9,0:53:37,50:47,Play Me This Song 9-2 (Early A Reminder) [Thom solo] 🌚,Thom solo acoustic recording. Vocals are very prominent. Same lyrics as studio version.,37,53,0,3217,47,50,0,3047,3217,170,TRUE,FALSE,FALSE,FALSE,FALSE,14
+10,0:58:17,0:00,Hospital 1 10-1 (Early Last Flowers) [Full band] + (Guitar Octaves),"First take early different lyrics, more band structured, heavy rock & roll sound",17,58,0,3497,0,0,0,0,229,229,FALSE,FALSE,FALSE,FALSE,FALSE,1
+10,0:58:17,3:49,Hospital delay 10-2 (Early Last Flowers) [Full band],Second take from a different rehearsal? Includes intro and effects with heavy rock & roll sound.,17,58,0,3497,49,3,0,229,336,107,FALSE,FALSE,FALSE,FALSE,FALSE,2
+10,0:58:17,5:36,True Love Waits (drums) 10-1 [Full band],"Full band, Instrumental, A jam, starts midway",17,58,0,3497,36,5,0,336,486,150,FALSE,FALSE,FALSE,FALSE,FALSE,3
+10,0:58:17,8:06,True Love Waits bass riff 10-2 [Full band],"Alternative arrangement, Stops midway",17,58,0,3497,6,8,0,486,595,109,FALSE,FALSE,FALSE,FALSE,FALSE,4
+10,0:58:17,9:55,Everyone 4-track (Early The National Anthem) 📼,"4-track demo, The National Anthem, same one as the cassette tape. 'Everyone' was the working title",17,58,0,3497,55,9,0,595,791,196,FALSE,FALSE,FALSE,TRUE,FALSE,5
+10,0:58:17,13:11,The Bends (4 Track Demo),"4-track demo, released on Long Live Tibet",17,58,0,3497,11,13,0,791,1082,291,FALSE,FALSE,FALSE,FALSE,FALSE,6
+10,0:58:17,18:02,Montee aka 'I Don't Want To Hurt You’’ [Thom solo with drum machine] 🌚,Acoustic guitar with drum machine. Most likely from the same 4-track demo.,17,58,0,3497,2,18,0,1082,1294,212,TRUE,FALSE,FALSE,FALSE,FALSE,7
+10,0:58:17,21:34,Let Down 10-1,"A more acoustic arrangement with no drums, different lyrics, also the gain is too fucking high",17,58,0,3497,34,21,0,1294,1641,347,FALSE,FALSE,FALSE,FALSE,FALSE,8
+10,0:58:17,27:21,Airbag drumming 10-1,"Live demo recording, slightly seeks and skips, also jamming at the end",17,58,0,3497,21,27,0,1641,1764,123,FALSE,FALSE,FALSE,FALSE,FALSE,9
+10,0:58:17,29:24,Airbag 10-2,"Jamming, features Colin’s bass playing isolated at some point",17,58,0,3497,24,29,0,1764,1818,54,FALSE,FALSE,FALSE,FALSE,FALSE,10
+10,0:58:17,30:18,You'll Never Know 10-1 [Thom solo] 🤤🌚,Thom on guitar,17,58,0,3497,18,30,0,1818,2073,255,TRUE,TRUE,FALSE,FALSE,FALSE,11
+10,0:58:17,34:33,You’ll Never Know 10-2[Thom solo] 🌚,"Another take of the same song
 “Don't stop, do you want to?”
-“You’ll never know”",23,58,0,3503,39,34,0,2079,2361,282,TRUE,FALSE,FALSE,FALSE,FALSE,12
-10,"00:58:23","39:21","Climbing Up The Walls read by little Dan Clements (from OKNOTOK) (10-13) 📼","The transcript from the cassette tapes",23,58,0,3503,21,39,0,2361,2444,83,FALSE,FALSE,FALSE,TRUE,FALSE,13
-10,"00:58:23","40:44","Climbing Up The Walls read by little Dan Clements, Slowed Down (10-14)","Kinda spooky not gonna lie or sumshin.",23,58,0,3503,44,40,0,2444,2596,152,FALSE,FALSE,FALSE,FALSE,FALSE,14
-10,"00:58:23","43:16","TR 606 drum machine pattern intro to 10-16 (10-15)","Roland TR-606 drum machine that Thom is playing along with (u/TraxusXII)",23,58,0,3503,16,43,0,2596,2642,46,FALSE,FALSE,FALSE,FALSE,FALSE,15
-10,"00:58:23","44:02","Unreleased Thom solo (Acoustic) with TR 606 10-3, 'If You Want To Stay' (10-16) 🌚",NA,23,58,0,3503,2,44,0,2642,2815,173,TRUE,FALSE,FALSE,FALSE,FALSE,16
-10,"00:58:23","46:55","Unreleased Thom solo (Acoustic) 10-4, 'Standin' Take 1 (10-17) 🌚","This is actually a scrapped part of Last Flowers. Thanks for the ID, u/MajorMajorSeven!",23,58,0,3503,55,46,0,2815,2907,92,TRUE,FALSE,FALSE,FALSE,FALSE,17
-10,"00:58:23","48:27","Unreleased Thom solo (Acoustic) same as 7-5 , 'Decided, If You Try' Alt. Lyrics, Take 1 (10-18) 🌚","Bedroom recording of Thom on the guitar",23,58,0,3503,27,48,0,2907,3080,173,TRUE,FALSE,FALSE,FALSE,FALSE,18
-10,"00:58:23","51:20","Unreleased Thom solo (Acoustic) same as 7-5 , 'Decided, If You Try' Alt. Lyrics, Take 2 (10-19) 🌚","Same song as above, just another take",23,58,0,3503,20,51,0,3080,3208,128,TRUE,FALSE,FALSE,FALSE,FALSE,19
-10,"00:58:23","53:28","Karma Police (Thom solo Acoustic, Alt. Lyrics, Different Key) (10-20) 🌚","Bedroom recording, only Thom and his guitar, different lyrics, and vocal key",23,58,0,3503,28,53,0,3208,3463,255,TRUE,FALSE,FALSE,FALSE,FALSE,20
-10,"00:58:23","57:43","Unreleased Thom solo (Acoustic) 10-5, 'I Hope You Choke' (10-21) 🌚","The same bedroom recording, only a short glimpse of this song before the tape ends",23,58,0,3503,43,57,0,3463,0,-3463,TRUE,FALSE,FALSE,FALSE,FALSE,21
-11,"01:02:01","0:00","Ambient vocals and effects (11-1)","A snippet of Stimmung ('Singcircle version') by Stockhausen
-Thanks for the ID, u/agentleBout!",1,2,1,3721,0,0,0,0,143,143,FALSE,FALSE,FALSE,FALSE,FALSE,1
-11,"01:02:01","2:23","Exit Music (Alt. Lyrics with Harmonies) (11-2)","Very different lyrics, thom singing with acoustic, sounds like colin singing with him",1,2,1,3721,23,2,0,143,349,206,FALSE,FALSE,FALSE,FALSE,FALSE,2
-11,"01:02:01","5:49","Unreleased Thom solo (with Electric guitar) 11-1, 'Don't Want To' (11-3) 🌚","Thom on tour bus with Jonny, playing together",1,2,1,3721,49,5,0,349,450,101,TRUE,FALSE,FALSE,FALSE,FALSE,3
-11,"01:02:01","7:30","Unreleased Thom solo (with Electric guitar) 11-2, 'One Look' (11-4) 🌚","Same ride, another song",1,2,1,3721,30,7,0,450,623,173,TRUE,FALSE,FALSE,FALSE,FALSE,4
-11,"01:02:01","10:23","Noise (11-5)","Maybe the rest of the tour bus ride",1,2,1,3721,23,10,0,623,680,57,FALSE,FALSE,FALSE,FALSE,FALSE,5
-11,"01:02:01","11:20","Unreleased Thom solo (with Electric guitar) 11-3, 'Let Me Go' (11-6) 🌚","“Let me go” thom solo acoustic song",1,2,1,3721,20,11,0,680,817,137,TRUE,FALSE,FALSE,FALSE,FALSE,6
-11,"01:02:01","13:37","Unreleased Thom solo (with Electric guitar) 11-3, Take 2 (Alt. Lyrics), 'Let Me Go' (11-7) 🌚","Same guitar melody, different lyrics",1,2,1,3721,37,13,0,817,886,69,TRUE,FALSE,FALSE,FALSE,FALSE,7
-11,"01:02:01","14:46","Climbing Up the Walls (Live Mansfield 1996, Soundboard) (11-8)","Live at Mansfield 1996, higher quality, SBD for sure",1,2,1,3721,46,14,0,886,1143,257,FALSE,FALSE,FALSE,FALSE,FALSE,8
-11,"01:02:01","19:03","I Promise (Live Mansfield 1996, Soundboard, OKNOTOK Promo) (11-9)","Live at Mansfield 1996, higher quality than the promo released before OKNOTOK",1,2,1,3721,3,19,0,1143,1376,233,FALSE,FALSE,FALSE,FALSE,FALSE,9
-11,"01:02:01","22:56","Paranoid Android (Live Mansfield 1996, Soundboard) (11-10)","Live at Mansfield 1996, best recording out there",1,2,1,3721,56,22,0,1376,1764,388,FALSE,FALSE,FALSE,FALSE,FALSE,10
-11,"01:02:01","29:24","Karma Police (Live Mansfield 1996, Soundboard) (11-11)","Live at Mansfield 1996",1,2,1,3721,24,29,0,1764,2034,270,FALSE,FALSE,FALSE,FALSE,FALSE,11
-11,"01:02:01","33:54","Unreleased Thom solo (Acoustic) 11-4, 'Do You Agree?' (11-12) 🌚","Thom solo acoustic recording",1,2,1,3721,54,33,0,2034,2198,164,TRUE,FALSE,FALSE,FALSE,FALSE,12
-11,"01:02:01","36:38","Unreleased Thom solo (Acoustic) 11-5, 'You Got Two Months To Get Out Before I Sic The Dogs On You' (11-13) 🌚","Thom acoustic solo recording",1,2,1,3721,38,36,0,2198,2372,174,TRUE,FALSE,FALSE,FALSE,FALSE,13
-11,"01:02:01","39:32","Let Down (Early Live with Organ) (11-14)","Live early version, an organ instead of Jonny at the ending",1,2,1,3721,32,39,0,2372,2690,318,FALSE,FALSE,FALSE,FALSE,FALSE,14
-11,"01:02:01","44:50","Unknown movie soundtrack (11-15)","Very droney, a recording of one of them playing maybe an organ or something else",1,2,1,3721,50,44,0,2690,2758,68,FALSE,FALSE,FALSE,FALSE,FALSE,15
-11,"01:02:01","45:58","Unknown woman laughing (11-16)","Evil laugh (duh)",1,2,1,3721,58,45,0,2758,2492,-266,FALSE,FALSE,FALSE,FALSE,FALSE,16
-11,"01:02:01","41:32","Let Down (Early Live) (11-17)","Another live recording, early version",1,2,1,3721,32,41,0,2492,3100,608,FALSE,FALSE,FALSE,FALSE,FALSE,17
-11,"01:02:01","51:40","Paranoid Android (Early Live) (11-18)","Live early version; I think this one could be the Hershey stadium in 1996",1,2,1,3721,40,51,0,3100,3499,399,FALSE,FALSE,FALSE,FALSE,FALSE,18
-11,"01:02:01","58:19","Karma Police (Early Live) (11-19)","Same show for sure, live and early version",1,2,1,3721,19,58,0,3499,5,-3494,FALSE,FALSE,FALSE,FALSE,FALSE,19
-12,"01:13:56","0:05","Climbing Up the Walls (12-1).","Live with early lyrics, full band.",56,13,1,4436,5,0,0,5,245,240,FALSE,FALSE,FALSE,FALSE,FALSE,1
-12,"01:13:56","4:05","Climbing Up the Walls (12-2)","Early lyrics, full band performance.
-Nearly identical to the studio version.",56,13,1,4436,5,4,0,245,490,245,FALSE,FALSE,FALSE,FALSE,FALSE,2
-12,"01:13:56","8:10","I Promise (12-3)","Full band live performance. Thom plays electric instead of acoustic. Early lyrics.",56,13,1,4436,10,8,0,490,723,233,FALSE,FALSE,FALSE,FALSE,FALSE,3
-12,"01:13:56","12:03","Paranoid Android (12-4)","Live, drums have lots of reverb in the beginning. Features organ. Some lyrical differences such as last verse in rain down part being missing. Different ending/breakdown.",56,13,1,4436,3,12,0,723,1136,413,FALSE,FALSE,FALSE,FALSE,FALSE,4
-12,"01:13:56","18:56","TV Show Noises (12-5)","“Tomorrow they shall be swimming in the new lake in babyland.”",56,13,1,4436,56,18,0,1136,1177,41,FALSE,FALSE,FALSE,FALSE,FALSE,5
-12,"01:13:56","19:37","No Surprises (12-6)","Thom: “Hello, we’re the support band”. Performance during the tour with Alanis Morisette most likely.",56,13,1,4436,37,19,0,1177,1408,231,FALSE,FALSE,FALSE,FALSE,FALSE,6
-12,"01:13:56","23:28","Paranoid Android (12-7)","Also features organ and some lyrical differences. Nearly identical to the previous above live version.",56,13,1,4436,28,23,0,1408,1818,410,FALSE,FALSE,FALSE,FALSE,FALSE,7
-12,"01:13:56","30:18","I Promise (12-8)","Same venue as previous live stuff here. Possibly some small differences in the lyrics. Features different bassline and washy organs.",56,13,1,4436,18,30,0,1818,2045,227,FALSE,FALSE,FALSE,FALSE,FALSE,8
-12,"01:13:56","34:05","Karma Police (12-9)","Right-channel-heavy mix. Some lyrical differences and prominent jonny piano magic. Same show as well as the rest.",56,13,1,4436,5,34,0,2045,2280,235,FALSE,FALSE,FALSE,FALSE,FALSE,9
-12,"01:13:56","38:00","Climbing Up the Walls (12-10)","Thom: “It’s a song about murder”. Lyrical differences and some sonic differences. Same performance too.
-P.S. Great Idea performing this to Alanis Morissette fans idiots.",56,13,1,4436,0,38,0,2280,2526,246,FALSE,FALSE,FALSE,FALSE,FALSE,10
-12,"01:13:56","42:06","I Promise (12-11)","Similar to previous performance on this disc.",56,13,1,4436,6,42,0,2526,2755,229,FALSE,FALSE,FALSE,FALSE,FALSE,11
-12,"01:13:56","45:55","Let Down (12-12)","Early version. Beautiful and rough performance. Lyrics are quite similar to the studio version and same with the music.",56,13,1,4436,55,45,0,2755,3053,298,FALSE,FALSE,FALSE,FALSE,FALSE,12
-12,"01:13:56","50:53","No Surprises (12-13)","Similar to studio. No real differences besides lack of some sonic textures and different backing vocals. Some slight melody difference at one pint.",56,13,1,4436,53,50,0,3053,3277,224,FALSE,FALSE,FALSE,FALSE,FALSE,13
-12,"01:13:56","54:37","Climbing Up the Walls (12-14)","Another early version that is again quite similar to the previous version in this disc. Nice scream at the end, Thom!",56,13,1,4436,37,54,0,3277,3524,247,FALSE,FALSE,FALSE,FALSE,FALSE,14
-12,"01:13:56","58:44","Electioneering (12-15)","Features cool breakdown, but besides that, it’s the same as the studio.",56,13,1,4436,44,58,0,3524,3728,204,FALSE,FALSE,FALSE,FALSE,FALSE,15
-12,"01:13:56","1:02:08","Paranoid Android (12-16)","Similar to all the other different live versions in this disk.
-Different lyrics: “if you’re so important, why don't you remember my name, are you ignorant?”, then says “stupid” followed by “motherfucking stupid” before they play the rain down part.",56,13,1,4436,8,2,1,3728,4152,424,FALSE,FALSE,FALSE,FALSE,FALSE,16
-12,"01:13:56","1:09:12","Let Down (12-17)","Really great performance similar to the studio version.",56,13,1,4436,12,9,1,4152,12,-4140,FALSE,FALSE,FALSE,FALSE,FALSE,17
-13,"00:50:15","0:12","Dialogue (13-1)",NA,15,50,0,3015,12,0,0,12,73,61,FALSE,FALSE,FALSE,FALSE,FALSE,1
-13,"00:50:15","1:13","Fridge Buzz (13-2) 📼","Literally a buzzing fridge",15,50,0,3015,13,1,0,73,107,34,FALSE,FALSE,FALSE,TRUE,FALSE,2
-13,"00:50:15","1:47","Palo Alto (Thom solo Acoustic) with 'Are You Someone?' section (13-3) 🌚","Thom acoustic demo (breaks into “Are You Someone” @ 3:21, then returns)",15,50,0,3015,47,1,0,107,341,234,TRUE,FALSE,FALSE,FALSE,FALSE,3
-13,"00:50:15","5:41","Field recording with TV audio (13-4)",NA,15,50,0,3015,41,5,0,341,882,541,FALSE,FALSE,FALSE,FALSE,FALSE,4
-13,"00:50:15","14:42","Exit Music (Thom solo Acoustic, Alt. Lyrics) (13-5) 🌚","Thom acoustic demo. Has alternate lyrics",15,50,0,3015,42,14,0,882,991,109,TRUE,FALSE,FALSE,FALSE,FALSE,5
-13,"00:50:15","16:31","Field recording with distant music (13-6)","Band rehearsing in the background?",15,50,0,3015,31,16,0,991,1665,674,FALSE,FALSE,FALSE,FALSE,FALSE,6
-13,"00:50:15","27:45","Lift (Live, Incomplete) (13-7)","Full band monitor. Incomplete.",15,50,0,3015,45,27,0,1665,1779,114,FALSE,FALSE,FALSE,FALSE,FALSE,7
-13,"00:50:15","29:39","TV dialogue and audio (13-8)","This audio can be heard in Fitter Happier",15,50,0,3015,39,29,0,1779,2144,365,FALSE,FALSE,FALSE,FALSE,FALSE,8
-13,"00:50:15","35:44","Ed and Thom talking with Unreleased Thom solo (Acoustic) 13-1, (13-9) 🌚","Talking before acoustic jam with Thom mumbling overtop",15,50,0,3015,44,35,0,2144,2260,116,TRUE,FALSE,FALSE,FALSE,FALSE,9
-13,"00:50:15","37:40","Unreleased Thom solo (Acoustic) instrumental 13-2, (13-10) 🌚","Reminiscent of I Might Be Wrong?",15,50,0,3015,40,37,0,2260,2297,37,TRUE,FALSE,FALSE,FALSE,FALSE,10
-13,"00:50:15","38:17","Unreleased Thom solo (Acoustic) instrumental 13-3, (13-11) 🌚","Might be Attention.",15,50,0,3015,17,38,0,2297,2372,75,TRUE,FALSE,FALSE,FALSE,FALSE,11
-13,"00:50:15","39:32","Unreleased Thom solo (Acoustic) 13-4, 'Driving Me Insane' (13-12) 🌚","“Lay it on the ground / it’s driving me insane”",15,50,0,3015,32,39,0,2372,2604,232,TRUE,FALSE,FALSE,FALSE,FALSE,12
-13,"00:50:15","43:24","Unreleased full band rehearsal/jam with drum solo 13-1 (13-13)","Full band. Jazzy. Phil drum solo in stereo midway",15,50,0,3015,24,43,0,2604,2761,157,FALSE,FALSE,FALSE,FALSE,FALSE,13
-13,"00:50:15","46:01","Unreleased Thom solo (Acoustic) instrumental, 'Western movie guitar' 13-5 (13-14) 🌚","Sounds like incidental western music",15,50,0,3015,1,46,0,2761,2784,23,TRUE,FALSE,FALSE,FALSE,FALSE,14
-13,"00:50:15","46:24","Choir from TV with dialogue (13-15)","Recording might be from another disc",15,50,0,3015,24,46,0,2784,2852,68,FALSE,FALSE,FALSE,FALSE,FALSE,15
-13,"00:50:15","47:32","Polyethylene Pt. 2 (Thom solo Acoustic, Alt. Lyrics) (13-16) 🌚","Thom acoustic demo. Alternate lyrics “The little things”",15,50,0,3015,32,47,0,2852,4,-2848,TRUE,FALSE,FALSE,FALSE,FALSE,16
-14,"01:13:39","0:04","Unreleased full band snippet (14-1)",NA,39,13,1,4419,4,0,0,4,8,4,FALSE,FALSE,FALSE,FALSE,FALSE,1
-14,"01:13:39","0:08","Lull (Early Rehearsal, Different Key) (14-2)",NA,39,13,1,4419,8,0,0,8,202,194,FALSE,FALSE,FALSE,FALSE,FALSE,2
-14,"01:13:39","3:22","Unreleased Full Band, 'Hurts To Walk' (14-3)","Another version of “Hurts To Walk” by “Thom” Yorke. Played in a “room.”",39,13,1,4419,22,3,0,202,265,63,FALSE,FALSE,FALSE,FALSE,FALSE,3
-14,"01:13:39","4:25","Unreleased Full Band, 'Hurts To Walk', Extra Snippet (14-4)","Cut in the tape, an extra snippet",39,13,1,4419,25,4,0,265,353,88,FALSE,FALSE,FALSE,FALSE,FALSE,4
-14,"01:13:39","5:53","Unreleased Full Band, 'Hurts To Walk,' (14-5)","Thom remarks about how he is proud of his funky clothes",39,13,1,4419,53,5,0,353,536,183,FALSE,FALSE,FALSE,FALSE,FALSE,5
-14,"01:13:39","8:56","Unreleased Full Band, 'He’s Not For Sale' (14-6)","Full band. Contains lyrics “little by little”; seems to have no relation to TKOL",39,13,1,4419,56,8,0,536,575,39,FALSE,FALSE,FALSE,FALSE,FALSE,6
-14,"01:13:39","9:35","Airbag (soundcheck 4/x/96) (14-7)","Early, acoustic, full band. Soundcheck, likely early April (4/8/96 or near).
+“You’ll never know”",17,58,0,3497,33,34,0,2073,2361,288,TRUE,FALSE,FALSE,FALSE,FALSE,12
+10,0:58:17,39:21,Climbing Up The Walls read by little Dan Clements (from OKNOTOK) 📼,The transcript from the cassette tapes,17,58,0,3497,21,39,0,2361,2437,76,FALSE,FALSE,FALSE,TRUE,FALSE,13
+10,0:58:17,40:37,"Climbing Up The Walls read by little Dan Clements, Slowed Down",Kinda spooky not gonna lie or sumshin.,17,58,0,3497,37,40,0,2437,2589,152,FALSE,FALSE,FALSE,FALSE,FALSE,14
+10,0:58:17,43:09,TR-606 Song 10-1 [drum loop],Roland TR-606 drum machine that Thom is playing along with (u/TraxusXII),17,58,0,3497,9,43,0,2589,2620,31,FALSE,FALSE,FALSE,FALSE,FALSE,15
+10,0:58:17,43:40,TR-606 Song 10-2 [Thom solo] 🌚,aka ‘If You Want to Stay’,17,58,0,3497,40,43,0,2620,2809,189,TRUE,FALSE,FALSE,FALSE,FALSE,16
+10,0:58:17,46:49,Easy Line for ‘Hospital’ (Early Last Flowers) [Thom solo] 🌚,"This is actually a scrapped part of Last Flowers. Thanks for the ID, u/MajorMajorSeven!",17,58,0,3497,49,46,0,2809,2899,90,TRUE,FALSE,FALSE,FALSE,FALSE,17
+10,0:58:17,48:19,The State Disco 10-1 [Thom solo]  🌚,Bedroom recording of Thom on the guitar,17,58,0,3497,19,48,0,2899,3072,173,TRUE,FALSE,FALSE,FALSE,FALSE,18
+10,0:58:17,51:12,The State Disco 10-2 [Thom solo] 🌚,"Same song as above, just another take",17,58,0,3497,12,51,0,3072,3200,128,TRUE,FALSE,FALSE,FALSE,FALSE,19
+10,0:58:17,53:20,Karma Police [Thom solo] 🌚,"Bedroom recording, only Thom and his guitar, different lyrics, and vocal key",17,58,0,3497,20,53,0,3200,3439,239,TRUE,FALSE,FALSE,FALSE,FALSE,20
+10,0:58:17,57:19,unknown song (lyric - 'I hope you choke on your nice cuisine') [Thom solo] 🌚,"The same bedroom recording, only a short glimpse of this song before the tape ends",17,58,0,3497,19,57,0,3439,3497,58,TRUE,FALSE,FALSE,FALSE,FALSE,21
+11,1:00:21,0:00,Stockhausen Voices (11-1),"A snippet of Stimmung ('Singcircle version') by Stockhausen
+Thanks for the ID, u/agentleBout!",21,0,1,3621,0,0,0,0,147,147,FALSE,FALSE,FALSE,FALSE,FALSE,1
+11,1:00:21,2:27,No Tomorrow (Early Exit Music),"Very different lyrics, thom singing with acoustic, sounds like colin singing with him",21,0,1,3621,27,2,0,147,359,212,FALSE,FALSE,FALSE,FALSE,FALSE,2
+11,1:00:21,5:59,Jonny's Ocean Song [Thom + Jonny] 🌚,"Thom on tour bus with Jonny, playing together",21,0,1,3621,59,5,0,359,458,99,TRUE,FALSE,FALSE,FALSE,FALSE,3
+11,1:00:21,7:38,Live A Little [Thom + Jonny] 🌚,"Same ride, another song",21,0,1,3621,38,7,0,458,633,175,TRUE,FALSE,FALSE,FALSE,FALSE,4
+11,1:00:21,10:33,Hotel Room Noise,Maybe the rest of the tour bus ride,21,0,1,3621,33,10,0,633,693,60,FALSE,FALSE,FALSE,FALSE,FALSE,5
+11,1:00:21,11:33,Mute Button 11-1 [Thom solo] 🌚,“Let me go” thom solo acoustic  song,21,0,1,3621,33,11,0,693,768,75,TRUE,FALSE,FALSE,FALSE,FALSE,6
+11,1:00:21,12:48,Mute Button 11-2 [Thom solo] 🌚,"Same guitar melody, different lyrics",21,0,1,3621,48,12,0,768,841,73,TRUE,FALSE,FALSE,FALSE,FALSE,7
+11,1:00:21,14:01,Climbing Up The Walls (Mansfield) [live - 14 August 1996],"Live at Mansfield 1996, higher quality, SBD for sure",21,0,1,3621,1,14,0,841,1094,253,FALSE,FALSE,FALSE,FALSE,FALSE,8
+11,1:00:21,18:14,I Promise (Mansfield) [live - 14 August 1996],"Live at Mansfield 1996, higher quality than the promo released before OKNOTOK",21,0,1,3621,14,18,0,1094,1331,237,FALSE,FALSE,FALSE,FALSE,FALSE,9
+11,1:00:21,22:11,Paranoid Android 11-1 (Mansfield) [live - 14 August 1996],"Live at Mansfield 1996, best recording out there",21,0,1,3621,11,22,0,1331,1745,414,FALSE,FALSE,FALSE,FALSE,FALSE,10
+11,1:00:21,29:05,Karma Police 11-1 (Mansfield) [live - 14 August 1996],Live at Mansfield 1996,21,0,1,3621,5,29,0,1745,2007,262,FALSE,FALSE,FALSE,FALSE,FALSE,11
+11,1:00:21,33:27,Service [Thom solo] 🌚,Thom solo acoustic recording,21,0,1,3621,27,33,0,2007,2178,171,TRUE,FALSE,FALSE,FALSE,FALSE,12
+11,1:00:21,36:18,‘Jaz’ Song [Thom solo] 🌚,Thom acoustic solo recording,21,0,1,3621,18,36,0,2178,2356,178,TRUE,FALSE,FALSE,FALSE,FALSE,13
+11,1:00:21,39:16,Let Down 11-1 (Galway) [live - 28 July 1996],"Live early version, an organ instead of Jonny at the ending",21,0,1,3621,16,39,0,2356,2675,319,FALSE,FALSE,FALSE,FALSE,FALSE,14
+11,1:00:21,44:35,[tape blip - (Citizen Cane Intro)],"Very droney,  a recording of one of them playing maybe an organ or something else",21,0,1,3621,35,44,0,2675,2496,-179,FALSE,FALSE,FALSE,FALSE,FALSE,15
+11,1:00:21,41:36,Let Down 11-2 (East Rutherford) [live - 19 August 1996],"Another live recording, early version",21,0,1,3621,36,41,0,2496,2967,471,FALSE,FALSE,FALSE,FALSE,FALSE,16
+11,1:00:21,49:27,Paranoid Android 11-2 (East Rutherford) [live - 19 August 1996],Live early version; I think this one could be the Hershey stadium in 1996,21,0,1,3621,27,49,0,2967,3382,415,FALSE,FALSE,FALSE,FALSE,FALSE,17
+11,1:00:21,56:22,Karma Police 11-2 (East Rutherford) [live - 19 August 1996],"Same show for sure, live and early version",21,0,1,3621,22,56,0,3382,3621,239,FALSE,FALSE,FALSE,FALSE,FALSE,18
+12,1:13:13,0:00,Climbing Up the Walls 12-1 [live],"Early lyrics, full band.",13,13,1,4393,0,0,0,0,245,245,FALSE,FALSE,FALSE,FALSE,FALSE,1
+12,1:13:13,4:05,Climbing Up the Walls 12-2 [live],"Early lyrics, full band performance.
+Nearly identical to the studio version.",13,13,1,4393,5,4,0,245,490,245,FALSE,FALSE,FALSE,FALSE,FALSE,2
+12,1:13:13,8:10,I Promise 12-1 [live],Full band performance. Thom plays electric instead of acoustic. Early lyrics.,13,13,1,4393,10,8,0,490,723,233,FALSE,FALSE,FALSE,FALSE,FALSE,3
+12,1:13:13,12:03,Paranoid Android 12-1 [live],Drums have lots of reverb in the beginning. Features organ. Some lyrical differences such as last verse in rain down part being missing. Different ending/breakdown.,13,13,1,4393,3,12,0,723,1131,408,FALSE,FALSE,FALSE,FALSE,FALSE,4
+12,1:13:13,18:51,No Surprises Please 12-1 [live],"Thom: “Hello, we’re the support band”. Performance during the tour with Alanis Morisette most likely.",13,13,1,4393,51,18,0,1131,1362,231,FALSE,FALSE,FALSE,FALSE,FALSE,5
+12,1:13:13,22:42,Paranoid Android 12-2 [live],Also features organ and some lyrical differences. Nearly identical to the previous above live version.,13,13,1,4393,42,22,0,1362,1771,409,FALSE,FALSE,FALSE,FALSE,FALSE,6
+12,1:13:13,29:31,I Promise 12-2 [live],Same venue as previous live stuff here. Possibly some small differences in the lyrics. Features different bassline and washy organs.,13,13,1,4393,31,29,0,1771,1998,227,FALSE,FALSE,FALSE,FALSE,FALSE,7
+12,1:13:13,33:18,Karma Police 12-1 [live],Right-channel-heavy mix. Some lyrical differences and prominent jonny piano magic. Same show as well as the rest.,13,13,1,4393,18,33,0,1998,2233,235,FALSE,FALSE,FALSE,FALSE,FALSE,8
+12,1:13:13,37:13,Climbing Up the Walls 12-3 [live],"Thom: “It’s a song about murder”. Lyrical differences and some sonic differences. Same performance too.
+P.S. Great Idea performing this to Alanis Morissette fans idiots.",13,13,1,4393,13,37,0,2233,2480,247,FALSE,FALSE,FALSE,FALSE,FALSE,9
+12,1:13:13,41:20,I Promise 12-3 [live],Similar to previous performance on this disc.,13,13,1,4393,20,41,0,2480,2708,228,FALSE,FALSE,FALSE,FALSE,FALSE,10
+12,1:13:13,45:08,Let Down 12-1 [live],Early version. Beautiful and rough performance. Lyrics are quite similar to the studio version and same with the music.,13,13,1,4393,8,45,0,2708,3006,298,FALSE,FALSE,FALSE,FALSE,FALSE,11
+12,1:13:13,50:06,No Surprises Please 12-2 [live],Similar to studio. No real differences besides lack of some sonic textures and different backing vocals. Some slight melody difference at one pint.,13,13,1,4393,6,50,0,3006,3230,224,FALSE,FALSE,FALSE,FALSE,FALSE,12
+12,1:13:13,53:50,Climbing Up the Walls 12-4 [live],"Another early version that is again quite similar to the previous version in this disc. Nice scream at the end, Thom!",13,13,1,4393,50,53,0,3230,3477,247,FALSE,FALSE,FALSE,FALSE,FALSE,13
+12,1:13:13,57:57,Electioneering [live],"Features cool breakdown, but besides that, it’s the same as the studio.",13,13,1,4393,57,57,0,3477,3681,204,FALSE,FALSE,FALSE,FALSE,FALSE,14
+12,1:13:13,1:01:21,Paranoid Android 12-3 [live],"Similar to all the other different live versions in this disk.
+Different lyrics: “if you’re so important, why don't you remember my name, are you ignorant?”, then says “stupid” followed by “motherfucking stupid” before they play the rain down part.",13,13,1,4393,21,1,1,3681,4105,424,FALSE,FALSE,FALSE,FALSE,FALSE,15
+12,1:13:13,1:08:25,Let Down 12-2 [live],Really great performance similar to the studio version.,13,13,1,4393,25,8,1,4105,4393,288,FALSE,FALSE,FALSE,FALSE,FALSE,16
+13,0:17:52,0:00,Silicon Valley (Early Palo Alto) [Thom solo],Has Jonny guiding Thom through some chords,52,17,0,1072,0,0,0,0,234,234,FALSE,FALSE,FALSE,FALSE,FALSE,1
+13,0:17:52,3:54,1000 Miles (Thom solo Acoustic) 🌚,Sounds like an early version of Exit Music,52,17,0,1072,54,3,0,234,342,108,TRUE,FALSE,FALSE,FALSE,FALSE,2
+13,0:17:52,5:42,Lift (Seattle) [live - 24 March 1996],Full band monitor. Incomplete.,52,17,0,1072,42,5,0,342,455,113,FALSE,FALSE,FALSE,FALSE,FALSE,3
+13,0:17:52,7:35,This Is The Panic Office [Thom solo] 🌚,Talking before acoustic jam with Thom mumbling overtop,52,17,0,1072,35,7,0,455,561,106,TRUE,FALSE,FALSE,FALSE,FALSE,4
+13,0:17:52,9:21,§? [Thom solo]  🌚,Reminiscent of I Might Be Wrong? Acoustic IInstrumental,52,17,0,1072,21,9,0,561,604,43,TRUE,FALSE,FALSE,FALSE,FALSE,5
+13,0:17:52,10:04,Harmonics Riff [Thom solo] 🌚,Might be Attention. Acoustic,52,17,0,1072,4,10,0,604,669,65,TRUE,FALSE,FALSE,FALSE,FALSE,6
+13,0:17:52,11:09,Lay Off The Beef [Thom solo] 🌚,“Lay it on the ground / it’s driving me insane” Acoustic.,52,17,0,1072,9,11,0,669,913,244,TRUE,FALSE,FALSE,FALSE,FALSE,7
+13,0:17:52,15:13,Polyethylene Pt. 2 [Thom solo] 🌚,Thom acoustic demo. Alternate lyrics “The little things”,52,17,0,1072,13,15,0,913,1072,159,TRUE,FALSE,FALSE,FALSE,FALSE,8
+14,1:12:22,0:00,[My New Clothes],Only a blip,22,12,1,4342,0,0,0,0,4,4,FALSE,FALSE,FALSE,FALSE,FALSE,1
+14,1:12:22,0:04,Ed’s Song (Early Lull),,22,12,1,4342,4,0,0,4,198,194,FALSE,FALSE,FALSE,FALSE,FALSE,2
+14,1:12:22,3:18,My New Clothes 14-1,Another version of “Hurts To Walk” by “Thom” Yorke.  Played in a “room.”,22,12,1,4342,18,3,0,198,260,62,FALSE,FALSE,FALSE,FALSE,FALSE,3
+14,1:12:22,4:20,My New Clothes 14-2,"Cut in the tape,  an extra snippet",22,12,1,4342,20,4,0,260,349,89,FALSE,FALSE,FALSE,FALSE,FALSE,4
+14,1:12:22,5:49,My New Clothes 14-3,Thom remarks about how he is proud of his funky clothes,22,12,1,4342,49,5,0,349,531,182,FALSE,FALSE,FALSE,FALSE,FALSE,5
+14,1:12:22,8:51,For Sale,Full band. Contains lyrics “little by little”; seems to have no relation to TKOL,22,12,1,4342,51,8,0,531,570,39,FALSE,FALSE,FALSE,FALSE,FALSE,6
+14,1:12:22,9:30,Airbag 14-1 (DC) [soundcheck - 10 April 1996],"Early, acoustic, full band.
 Alternate lyrics:
-“In the next world war, an angel at my door..”",39,13,1,4419,35,9,0,575,792,217,FALSE,FALSE,FALSE,FALSE,FALSE,7
-14,"01:13:39","13:12","Noise - Chatter (14-8)","Overlapping conversation, sounds English",39,13,1,4419,12,13,0,792,848,56,FALSE,FALSE,FALSE,FALSE,FALSE,8
-14,"01:13:39","14:08","Electioneering (live 4/8/96 Odeon, Cleveland, OH, Alt. Lyrics) (14-9)","“This is a new song.”
-Some lyrical variation from final version. Also screams potatoes.",39,13,1,4419,8,14,0,848,1053,205,FALSE,FALSE,FALSE,FALSE,FALSE,9
-14,"01:13:39","17:33","Lift (live 4/8/96 Odeon, Cleveland, OH) (14-10)","Same show, but actually the firt song in the set: ‘O Superman’ by Laurie Anderson intro transitions into ‘Lift’.
-Thanks to u/shanerichmond for fix!",39,13,1,4419,33,17,0,1053,1299,246,FALSE,FALSE,FALSE,FALSE,FALSE,10
-14,"01:13:39","21:39","Airbag (live 4/10/96 9:30 Club, Washington, DC) (14-11)","Similar to 9:33 above.",39,13,1,4419,39,21,0,1299,1575,276,FALSE,FALSE,FALSE,FALSE,FALSE,11
-14,"01:13:39","26:15","Airbag (live 4/11/96 Trocadero, Philadelphia, PA) (14-12)","Acoustic again, live. See above.",39,13,1,4419,15,26,0,1575,1843,268,FALSE,FALSE,FALSE,FALSE,FALSE,12
-14,"01:13:39","30:43","Attention, (soundcheck 4/x/96) (14-13)","Full band soundcheck.
-“Joy of the uprising, an action with some meaning” Very likely from 4/11 or 4/12/96",39,13,1,4419,43,30,0,1843,2075,232,FALSE,FALSE,FALSE,FALSE,FALSE,13
-14,"01:13:39","34:35","Attention, (soundcheck 4/x/96) (14-14)","Soundcheck. See above",39,13,1,4419,35,34,0,2075,2363,288,FALSE,FALSE,FALSE,FALSE,FALSE,14
-14,"01:13:39","39:23","Unreleased full band song, instrumental (soundcheck 4/x/96) (14-15)","Full band recording. Sounds serene, twangy, and folk rocky.",39,13,1,4419,23,39,0,2363,2435,72,FALSE,FALSE,FALSE,FALSE,FALSE,15
-14,"01:13:39","40:35","Lift (soundcheck 4/x/96) (14-16)","Skips around a couple times, resolves to Lift",39,13,1,4419,35,40,0,2435,2659,224,FALSE,FALSE,FALSE,FALSE,FALSE,16
-14,"01:13:39","44:19","Airbag (soundcheck 4/x/96) (14-17)","Jamming on Airbag
-“It’s on tape, yeah?” -Thom",39,13,1,4419,19,44,0,2659,2677,18,FALSE,FALSE,FALSE,FALSE,FALSE,17
-14,"01:13:39","44:37","Unreleased Thom solo vocal with bleedthrough from acoustic guitar (soundcheck 4/x/96) (14-18) 🌚","Thom singing over muted acoustic guitar track.
+“In the next world war, an angel at my door..”",22,12,1,4342,30,9,0,570,788,218,FALSE,FALSE,FALSE,FALSE,FALSE,7
+14,1:12:22,13:08,Electioneering 14-1 (DC) [live - 10 April 1996],"“This is a new song.”
+Some lyrical variation from final version. Also screams potatoes.",22,12,1,4342,8,13,0,788,993,205,FALSE,FALSE,FALSE,FALSE,FALSE,8
+14,1:12:22,16:33,Lift 14-1 (Cleveland) [live - 8 April 1996],"Same live session, transitions to Lift, with O Superman by Laurie Anderson intro. Good performance.
+Thanks to u/shanerichmond for fix!",22,12,1,4342,33,16,0,993,1238,245,FALSE,FALSE,FALSE,FALSE,FALSE,9
+14,1:12:22,20:38,Airbag 14-2 (Philadelphia) [live - 11 April 1996],Similar to 9:33 above.,22,12,1,4342,38,20,0,1238,1495,257,FALSE,FALSE,FALSE,FALSE,FALSE,10
+14,1:12:22,24:55,Airbag 14-3 (DC) [live - 10 April 1996],"Acoustic again, live. See above.",22,12,1,4342,55,24,0,1495,1763,268,FALSE,FALSE,FALSE,FALSE,FALSE,11
+14,1:12:22,29:23,Attenzione! 14-1 (Fast),"Full band recording.
+“Joy of the uprising, an action with some meaning”",22,12,1,4342,23,29,0,1763,1995,232,FALSE,FALSE,FALSE,FALSE,FALSE,12
+14,1:12:22,33:15,Attenzione! 14-2 (Minneapolis) [soundcheck - 3 April 1996],,22,12,1,4342,15,33,0,1995,2283,288,FALSE,FALSE,FALSE,FALSE,FALSE,13
+14,1:12:22,38:03,Stampeding Elephants,"Full band recording. Sounds serene, twangy, and folk rocky.",22,12,1,4342,3,38,0,2283,2354,71,FALSE,FALSE,FALSE,FALSE,FALSE,14
+14,1:12:22,39:14,Lift 14-2 (Minneapolis) [soundcheck - 3 April 1996],"Skips around a couple times, resolves to Lift",22,12,1,4342,14,39,0,2354,2578,224,FALSE,FALSE,FALSE,FALSE,FALSE,15
+14,1:12:22,42:58,Airbag 14-4 (Minneapolis acoustic) [soundcheck - 3 April 1996 - fragment] [duplicate],"Jamming on Airbag
+“It’s on tape, yeah?” -Thom",22,12,1,4342,58,42,0,2578,2596,18,FALSE,FALSE,FALSE,FALSE,FALSE,16
+14,1:12:22,43:16,Manhattan Dogs [Thom solo] 🌚,"Thom singing over muted acoustic guitar track.
 “Is anyone around? I think you’re crazy for wanting me to tell”
-“You’re always on the phone”",39,13,1,4419,37,44,0,2677,2949,272,TRUE,FALSE,FALSE,FALSE,FALSE,18
-14,"01:13:39","49:09","Paranoid Android (soundcheck 4/x/96) (14-19)","Thom directing volume levels a bit. Pretty unstructured. Slight variation in “rain down” section lyrics; “It’s gonna rain down on you”",39,13,1,4419,9,49,0,2949,3135,186,FALSE,FALSE,FALSE,FALSE,FALSE,19
-14,"01:13:39","52:15","Airbag (soundcheck 4/x/96) (14-20)","See all above instances of Airbag it’s very similar. Maybe some extra synth-y stuff in this one",39,13,1,4419,15,52,0,3135,3420,285,FALSE,FALSE,FALSE,FALSE,FALSE,20
-14,"01:13:39","57:00","Electioneering (Early Live, Probable Monitor Mix) (14-21)","Sounds weirdly distant. Vocal tracks almost seem isolated? “Give me one of them prizes”, “Doin’ it all” lines are in here. Must be an early performance.",39,13,1,4419,0,57,0,3420,3627,207,FALSE,FALSE,FALSE,FALSE,FALSE,21
-14,"01:13:39","1:00:27","I Promise (Live with Fast Forwarded Thom Intro) (14-22)","Fast-forwarded intro speech; “I can’t read music, these are words.” --- “-REM tour, and I still look” --- “-he said he didn’t mind. This is a new song, called I Promise”. Has “I won’t fool around no more” verse.",39,13,1,4419,27,0,1,3627,3877,250,FALSE,FALSE,FALSE,FALSE,FALSE,22
-14,"01:13:39","1:04:37","Paranoid Android (Early Live, Alt. Lyrics) (14-23)","“Why don’t you remember my name” part. Alternate “rain down” lyrics from above (49:04) are not present here. “Hallelujah” variation of “rain down” lyrics also absent. Thom sings a backing harmony part here after the normal lyrics. No “that’s it sir” part.",39,13,1,4419,37,4,1,3877,3989,112,FALSE,FALSE,FALSE,FALSE,FALSE,23
-14,"01:13:39","1:06:29","Attention (Full Band Version), Take 14-3 (14-24)","Cuts in for first verse, no intro. Unsure of lyrical differences with other versions on this file.",39,13,1,4419,29,6,1,3989,4160,171,FALSE,FALSE,FALSE,FALSE,FALSE,24
-14,"01:13:39","1:09:20","Attention (Full Band Version with Backing Vocals), Take 14-4 (14-25)","not sure I’ve heard these lyrics yet? “There’s nothing better to do / I’m taking off my clothes because I’ve got the hots for you”. No backing vocals.",39,13,1,4419,20,9,1,4160,4244,84,FALSE,FALSE,FALSE,FALSE,FALSE,25
-14,"01:13:39","1:10:44","I Promise (Live 4-12-96 at Roseland Ballroom) (14-26)","“This is for the girl who just said ‘Thom help me I’m dying’ down in the front!” Drums similar to remastered version. Has extra “fool around” verse, but no “funny look” line from 1:00:26 version.
-According to redditor /u/EsotericCD, this performance is from 4/12/96 Roseland Ballroom. Thanks for the ID!",39,13,1,4419,44,10,1,4244,2,-4242,FALSE,FALSE,FALSE,FALSE,FALSE,26
-15,"00:58:20","0:02","Three Seconds of Subterranean Homesick Alien (15-1)","What do I need to put here? Like seriously.",20,58,0,3500,2,0,0,2,7,5,FALSE,FALSE,FALSE,FALSE,FALSE,1
-15,"00:58:20","0:07","Karma Police - Final Version (15-2)","Final Version",20,58,0,3500,7,0,0,7,297,290,FALSE,FALSE,FALSE,FALSE,FALSE,2
-15,"00:58:20","4:57","Let Down - Near-Final Version with Acoustic Intro (15-3)","Slightly different from the album version. Acoustic guitar from ending is now in the intro.",20,58,0,3500,57,4,0,297,613,316,FALSE,FALSE,FALSE,FALSE,FALSE,3
-15,"00:58:20","10:13","Lift - Alternate Version, Mix #1 (15-4) ⭐","Full band finished studio recording. It's incredible.",20,58,0,3500,13,10,0,613,862,249,FALSE,FALSE,TRUE,FALSE,FALSE,4
-15,"00:58:20","14:22","Silence / Lift synth intro bit (15-5)","Cut synth bit from previous lift intro",20,58,0,3500,22,14,0,862,895,33,FALSE,FALSE,FALSE,FALSE,FALSE,5
-15,"00:58:20","14:55","Airbag - Late/Final Version (15-6)","Late/finished version. may be a different vocal take; different reverb.",20,58,0,3500,55,14,0,895,1190,295,FALSE,FALSE,FALSE,FALSE,FALSE,6
-15,"00:58:20","19:50","Electioneering - Final Version (15-7)","Late/finished version",20,58,0,3500,50,19,0,1190,1459,269,FALSE,FALSE,FALSE,FALSE,FALSE,7
-15,"00:58:20","24:19","A Reminder - Final Version (15-8)","Late/finished version",20,58,0,3500,19,24,0,1459,1698,239,FALSE,FALSE,FALSE,FALSE,FALSE,8
-15,"00:58:20","28:18","Alien synths",NA,20,58,0,3500,18,28,0,1698,1706,8,FALSE,FALSE,FALSE,FALSE,FALSE,9
-15,"00:58:20","28:26","Subterranean Homesick Alien - Late/Final Version (15-10)","Late/finished version",20,58,0,3500,26,28,0,1706,1997,291,FALSE,FALSE,FALSE,FALSE,FALSE,10
-15,"00:58:20","33:17","Subterranean Homesick Alien - Late/Final Version (15-11)","Late/finished version. Must be something different..?",20,58,0,3500,17,33,0,1997,2287,290,FALSE,FALSE,FALSE,FALSE,FALSE,11
-15,"00:58:20","38:07","Subterranean Homesick Alien - Late/Final Version (15-12)","Late/finished version. Must be something different..?",20,58,0,3500,7,38,0,2287,2577,290,FALSE,FALSE,FALSE,FALSE,FALSE,12
-15,"00:58:20","42:57","No Surprises - Late Mix, Original Speed (15-13)","Different vocal take from album version. Original recorded speed; half-step down from album version.",20,58,0,3500,57,42,0,2577,2826,249,FALSE,FALSE,FALSE,FALSE,FALSE,13
-15,"00:58:20","47:06","Exit Music (For A Film) - Late Mix (15-14)","Starting with a thom chuckle and an “Okay”. Same as Tape 18 version?",20,58,0,3500,6,47,0,2826,3111,285,FALSE,FALSE,FALSE,FALSE,FALSE,14
-15,"00:58:20","51:51","Paranoid Android - Late Mix (5-15)","Synths seem quieter. Slightly different mix.",20,58,0,3500,51,51,0,3111,6,-3105,FALSE,FALSE,FALSE,FALSE,FALSE,15
-16,"01:07:54","0:06","Airbag - Unmastered Album Version (16-1)",NA,54,7,1,4074,6,0,0,6,287,281,FALSE,FALSE,FALSE,FALSE,FALSE,1
-16,"01:07:54","4:47","Paranoid Android - Unmastered Album Version (16-2)",NA,54,7,1,4074,47,4,0,287,671,384,FALSE,FALSE,FALSE,FALSE,FALSE,2
-16,"01:07:54","11:11","Subterranean Homesick Alien - Unmastered Album Version (16-3)",NA,54,7,1,4074,11,11,0,671,941,270,FALSE,FALSE,FALSE,FALSE,FALSE,3
-16,"01:07:54","15:41","Exit Music (For A Film) - Unmastered Album Version (16-4)",NA,54,7,1,4074,41,15,0,941,1210,269,FALSE,FALSE,FALSE,FALSE,FALSE,4
-16,"01:07:54","20:10","Let Down - Unmastered Album Version with Early Fade-Out (16-5)",NA,54,7,1,4074,10,20,0,1210,1436,226,FALSE,FALSE,FALSE,FALSE,FALSE,5
-16,"01:07:54","23:56","Fitter Happier - Unmastered Album Version (16-6)",NA,54,7,1,4074,56,23,0,1436,1557,121,FALSE,FALSE,FALSE,FALSE,FALSE,6
-16,"01:07:54","25:57","Climbing Up The Walls - Unmastered Album Version (16-7)",NA,54,7,1,4074,57,25,0,1557,1841,284,FALSE,FALSE,FALSE,FALSE,FALSE,7
-16,"01:07:54","30:41","No Surprises - Unmastered Album Version (16-8)",NA,54,7,1,4074,41,30,0,1841,2068,227,FALSE,FALSE,FALSE,FALSE,FALSE,8
-16,"01:07:54","34:28","Electioneering - Unmastered Album Version (16-9)",NA,54,7,1,4074,28,34,0,2068,2302,234,FALSE,FALSE,FALSE,FALSE,FALSE,9
-16,"01:07:54","38:22","Lucky - Unmastered Album Version (16-10)",NA,54,7,1,4074,22,38,0,2302,2561,259,FALSE,FALSE,FALSE,FALSE,FALSE,10
-16,"01:07:54","42:41","Karma Police - Unmastered Album Version (16-11)",NA,54,7,1,4074,41,42,0,2561,2824,263,FALSE,FALSE,FALSE,FALSE,FALSE,11
-16,"01:07:54","47:04","The Tourist - Unmastered Album Version (16-12)",NA,54,7,1,4074,4,47,0,2824,3152,328,FALSE,FALSE,FALSE,FALSE,FALSE,12
-16,"01:07:54","52:32","A Reminder - Unmastered Album Version (16-13)",NA,54,7,1,4074,32,52,0,3152,3385,233,FALSE,FALSE,FALSE,FALSE,FALSE,13
-16,"01:07:54","56:25","Lift - Alternate Version, Mix #2 (16-14)⭐",NA,54,7,1,4074,25,56,0,3385,3615,230,FALSE,FALSE,TRUE,FALSE,FALSE,14
-16,"01:07:54","1:00:15","Lift - Alternate Version, Mix #3 (16-15)⭐",NA,54,7,1,4074,15,0,1,3615,3839,224,FALSE,FALSE,TRUE,FALSE,FALSE,15
-16,"01:07:54","1:03:59","Noise - Fitter Happier beeps (16-16)",NA,54,7,1,4074,59,3,1,3839,3854,15,FALSE,FALSE,FALSE,FALSE,FALSE,16
-16,"01:07:54","1:04:14","Polyethylene Pt 2 - Late Mix w/ Vocal Effect (16-17)",NA,54,7,1,4074,14,4,1,3854,4074,220,FALSE,FALSE,FALSE,FALSE,FALSE,17
-16,"01:07:54","1:07:54","Noise - guitar bit (16-18)",NA,54,7,1,4074,54,7,1,4074,11,-4063,FALSE,FALSE,FALSE,FALSE,FALSE,18
-17,"00:27:16","0:11","The Tourist - Unmastered Album Version (17-1)",NA,16,27,0,1636,11,0,0,11,349,338,FALSE,FALSE,FALSE,FALSE,FALSE,1
-17,"00:27:16","5:49","The Tourist - Unmastered Album Version (17-2)",NA,16,27,0,1636,49,5,0,349,686,337,FALSE,FALSE,FALSE,FALSE,FALSE,2
-17,"00:27:16","11:26","Polyethylene Pt 2 - Near-Final Mix (17-3)","With its own count-in. Close to album version. Slightly different vocals, less compressed.",16,27,0,1636,26,11,0,686,923,237,FALSE,FALSE,FALSE,FALSE,FALSE,3
-17,"00:27:16","15:23","Polyethylene Pt 2 - Near-Final Mix (17-4)","Same as above, may be a slightly different mix.",16,27,0,1636,23,15,0,923,1150,227,FALSE,FALSE,FALSE,FALSE,FALSE,4
-17,"00:27:16","19:10","Fitter Happier - Unmastered Album Version (17-5)",NA,16,27,0,1636,10,19,0,1150,1290,140,FALSE,FALSE,FALSE,FALSE,FALSE,5
-17,"00:27:16","21:30","Unreleased Thom Solo (Piano) - “Tomorrow Night In Paris” (17-6) 🌚","“Everybody wants you but nobody wants you”",16,27,0,1636,30,21,0,1290,1555,265,TRUE,FALSE,FALSE,FALSE,FALSE,6
-17,"00:27:16","25:55","Unreleased Thom Solo (Piano) - “Tomorrow Night In Paris”, Piano Only (17-7) 🌚",NA,16,27,0,1636,55,25,0,1555,0,-1555,TRUE,FALSE,FALSE,FALSE,FALSE,7
-18,"00:41:52","0:00","Chatter/wind noise (18-1)","“Hello… It’s working…”",52,41,0,2512,0,0,0,0,75,75,FALSE,FALSE,FALSE,FALSE,FALSE,1
-18,"00:41:52","1:15","A Reminder - Thom A Cappella Take 1 (18-2)","Thom singing quietly by himself outside",52,41,0,2512,15,1,0,75,226,151,FALSE,FALSE,FALSE,FALSE,FALSE,2
-18,"00:41:52","3:46","Wind noise (18-3)",NA,52,41,0,2512,46,3,0,226,300,74,FALSE,FALSE,FALSE,FALSE,FALSE,3
-18,"00:41:52","5:00","A Reminder - Thom A Cappella Take 2 (18-4)",NA,52,41,0,2512,0,5,0,300,437,137,FALSE,FALSE,FALSE,FALSE,FALSE,4
-18,"00:41:52","7:17","Wind noise (18-5)",NA,52,41,0,2512,17,7,0,437,481,44,FALSE,FALSE,FALSE,FALSE,FALSE,5
-18,"00:41:52","8:01","A Reminder - Thom A Cappella Take 3 (18-6)","Cut off at the end",52,41,0,2512,1,8,0,481,627,146,FALSE,FALSE,FALSE,FALSE,FALSE,6
-18,"00:41:52","10:27","Wind noise (18-7)",NA,52,41,0,2512,27,10,0,627,643,16,FALSE,FALSE,FALSE,FALSE,FALSE,7
-18,"00:41:52","10:43","A Reminder - Thom A Cappella Take 4 (18-8)",NA,52,41,0,2512,43,10,0,643,730,87,FALSE,FALSE,FALSE,FALSE,FALSE,8
-18,"00:41:52","12:10","Wind noise (18-9)",NA,52,41,0,2512,10,12,0,730,757,27,FALSE,FALSE,FALSE,FALSE,FALSE,9
-18,"00:41:52","12:37","A Reminder - Thom A Cappella Take 5 (18-10)","In a new key",52,41,0,2512,37,12,0,757,883,126,FALSE,FALSE,FALSE,FALSE,FALSE,10
-18,"00:41:52","14:43","Unreleased Thom solo (Acoustic) 18-1 ('What Did You Mean'), Take 1 (18-11) 🌚",NA,52,41,0,2512,43,14,0,883,1043,160,TRUE,FALSE,FALSE,FALSE,FALSE,11
-18,"00:41:52","17:23","Unreleased Thom solo (Acoustic) 18-1 ('What Did You Mean'), Take 2 (18-12) 🌚",NA,52,41,0,2512,23,17,0,1043,1176,133,TRUE,FALSE,FALSE,FALSE,FALSE,12
-18,"00:41:52","19:36","Unreleased Thom solo (Acoustic) 18-1 ('What Did You Mean'), Take 3 (18-13) 🌚","Clearer vocals
-“That wasn’t a shooting star, that was an airplane landing”",52,41,0,2512,36,19,0,1176,1291,115,TRUE,FALSE,FALSE,FALSE,FALSE,13
-18,"00:41:52","21:31","Unreleased Thom solo (Acoustic) 18-1 ('What Did You Mean'), Take 4 (Guitar Only) (18-14) 🌚",NA,52,41,0,2512,31,21,0,1291,1341,50,TRUE,FALSE,FALSE,FALSE,FALSE,14
-18,"00:41:52","22:21","Unreleased Thom solo (Acoustic) 18-2 ('You’re a Sleazy Bastard, You’re No Friend of Mine') (18-15) 🌚","Rock/bluesy
+“You’re always on the phone”",22,12,1,4342,16,43,0,2596,2868,272,TRUE,FALSE,FALSE,FALSE,FALSE,17
+14,1:12:22,47:48,Paranoid Android 14-1 (NY) [soundcheck - 12 April 1996],Thom directing volume levels a bit. Slight variation in “rain down” section lyrics; “It’s gonna rain down on you”,22,12,1,4342,48,47,0,2868,3060,192,FALSE,FALSE,FALSE,FALSE,FALSE,18
+14,1:12:22,51:00,Airbag 14-5 (NY) [soundcheck - 12 April 1996],See all above instances of Airbag it’s very similar. Maybe some extra synth-y stuff in this one,22,12,1,4342,0,51,0,3060,3339,279,FALSE,FALSE,FALSE,FALSE,FALSE,19
+14,1:12:22,55:39,Electioneering 14-2 (San Diego) [live - 30 March 1996],"Sounds weirdly distant. Vocal tracks almost seem isolated? “Give me one of them prizes”, “Doin’ it all” lines are in here. Must be an early performance.",22,12,1,4342,39,55,0,3339,3552,213,FALSE,FALSE,FALSE,FALSE,FALSE,20
+14,1:12:22,59:12,I Promise 14-1 [live],"Fast-forwarded intro speech; “I can’t read music, these are words.” --- “-REM tour, and I still look” --- “-he said he didn’t mind. This is a new song, called I Promise”. Has “I won’t fool around no more” verse.",22,12,1,4342,12,59,0,3552,3803,251,FALSE,FALSE,FALSE,FALSE,FALSE,21
+14,1:12:22,1:03:23,1/2 Paranoid Android? 14-2,“Why don’t you remember my name” part. Alternate “rain down” lyrics from above (49:04) are not present here. “Hallelujah” variation of “rain down” lyrics also absent. Thom sings a backing harmony part here after the normal lyrics. No “that’s it sir” part.,22,12,1,4342,23,3,1,3803,3916,113,FALSE,FALSE,FALSE,FALSE,FALSE,22
+14,1:12:22,1:05:16,Attenzione! 14-1 (Palo Alto) [soundcheck - 28 March 1996],"Cuts in for first verse, no intro. Unsure of lyrical differences with other versions on this file.",22,12,1,4342,16,5,1,3916,4126,210,FALSE,FALSE,FALSE,FALSE,FALSE,23
+14,1:12:22,1:08:46,Attenzione! 14-2 (Palo Alto) [soundcheck - 28 March 1996],not sure I’ve heard these lyrics yet? “There’s nothing better to do / I’m taking off my clothes because I’ve got the hots for you”. No backing vocals.,22,12,1,4342,46,8,1,4126,4170,44,FALSE,FALSE,FALSE,FALSE,FALSE,24
+14,1:12:22,1:09:30,I Promise 14-2 (NY) [live - 12 April 1996],"“This is for the girl who just said ‘Thom help me I’m dying’ down in the front!” Drums similar to remastered version. Has extra “fool around” verse, but no “funny look” line from 1:00:26 version.
+According to redditor /u/EsotericCD, this performance is from 4/12/96 Roseland Ballroom. Thanks for the ID!",22,12,1,4342,30,9,1,4170,4342,172,FALSE,FALSE,FALSE,FALSE,FALSE,25
+15,0:56:10,0:00,Three Seconds of Subterranean Homesick Alien,What do I need to put here? Like seriously.,10,56,0,3370,0,0,0,0,3,3,FALSE,FALSE,FALSE,FALSE,FALSE,1
+15,0:56:10,0:03,Karma Police - Final Version,Final Version,10,56,0,3370,3,0,0,3,279,276,FALSE,FALSE,FALSE,FALSE,FALSE,2
+15,0:56:10,4:39,Let Down - Near-Final Version with Acoustic Intro,Slightly different from the album version. Acoustic guitar from ending is now in the intro.,10,56,0,3370,39,4,0,279,586,307,FALSE,FALSE,FALSE,FALSE,FALSE,3
+15,0:56:10,9:46,"Lift - Alternate Version, Mix #1 ⭐",Full band finished studio recording. It's incredible.,10,56,0,3370,46,9,0,586,835,249,FALSE,FALSE,TRUE,FALSE,FALSE,4
+15,0:56:10,13:55,Airbag - Late/Final Version,Late/finished version. may be a different vocal take; different reverb.,10,56,0,3370,55,13,0,835,1122,287,FALSE,FALSE,FALSE,FALSE,FALSE,5
+15,0:56:10,18:42,Electioneering - Final Version,Late/finished version,10,56,0,3370,42,18,0,1122,1358,236,FALSE,FALSE,FALSE,FALSE,FALSE,6
+15,0:56:10,22:38,A Reminder - Final Version,Late/finished version,10,56,0,3370,38,22,0,1358,1592,234,FALSE,FALSE,FALSE,FALSE,FALSE,7
+15,0:56:10,26:32,Uptight (less room) - Late/Final Version,Early title of Subterranean Homesick Alien. Late/finished version,10,56,0,3370,32,26,0,1592,1879,287,FALSE,FALSE,FALSE,FALSE,FALSE,8
+15,0:56:10,31:19,Uptight (less drums) - Late/Final Version,Late/finished version. Must be something different..?,10,56,0,3370,19,31,0,1879,2165,286,FALSE,FALSE,FALSE,FALSE,FALSE,9
+15,0:56:10,36:05,Uptight (Nigel's master) - Late/Final Version,Late/finished version. Must be something different..?,10,56,0,3370,5,36,0,2165,2452,287,FALSE,FALSE,FALSE,FALSE,FALSE,10
+15,0:56:10,40:52,"No Surprises Please - Late Mix, Original Speed",Different vocal take from album version. Original recorded speed; half-step down from album version.,10,56,0,3370,52,40,0,2452,2700,248,FALSE,FALSE,FALSE,FALSE,FALSE,11
+15,0:56:10,45:00,Exit Music (For A Film) - Late Mix,Starting with a thom chuckle and an “Okay”. Same as Tape 18 version?,10,56,0,3370,0,45,0,2700,2980,280,FALSE,FALSE,FALSE,FALSE,FALSE,12
+15,0:56:10,49:40,Paranoid Android - Late Mix,Synths seem quieter. Slightly different mix.,10,56,0,3370,40,49,0,2980,3370,390,FALSE,FALSE,FALSE,FALSE,FALSE,13
+16,1:08:04,0:00,Airbag (unmastered album version),,4,8,1,4084,0,0,0,0,287,287,FALSE,FALSE,FALSE,FALSE,FALSE,1
+16,1:08:04,4:47,Paranoid Android (unmastered album version),,4,8,1,4084,47,4,0,287,671,384,FALSE,FALSE,FALSE,FALSE,FALSE,2
+16,1:08:04,11:11,Subterranean Homesick Alien (unmastered album version),,4,8,1,4084,11,11,0,671,939,268,FALSE,FALSE,FALSE,FALSE,FALSE,3
+16,1:08:04,15:39,Exit Music (For A Film) (unmastered album version),,4,8,1,4084,39,15,0,939,1210,271,FALSE,FALSE,FALSE,FALSE,FALSE,4
+16,1:08:04,20:10,Let Down (early fade out),,4,8,1,4084,10,20,0,1210,1435,225,FALSE,FALSE,FALSE,FALSE,FALSE,5
+16,1:08:04,23:55,Fitter Happier (unmastered near-final version),Unclear if this is the finished mix as there is another mix on disc 17.,4,8,1,4084,55,23,0,1435,1557,122,FALSE,FALSE,FALSE,FALSE,FALSE,6
+16,1:08:04,25:57,Climbing Up The Walls (unmastered album version),,4,8,1,4084,57,25,0,1557,1841,284,FALSE,FALSE,FALSE,FALSE,FALSE,7
+16,1:08:04,30:41,No Surprises (unmastered album version),,4,8,1,4084,41,30,0,1841,2068,227,FALSE,FALSE,FALSE,FALSE,FALSE,8
+16,1:08:04,34:28,Electioneering (unmastered album version),,4,8,1,4084,28,34,0,2068,2301,233,FALSE,FALSE,FALSE,FALSE,FALSE,9
+16,1:08:04,38:21,Lucky (unmastered album version),,4,8,1,4084,21,38,0,2301,2560,259,FALSE,FALSE,FALSE,FALSE,FALSE,10
+16,1:08:04,42:40,Karma Police (unmastered album version),,4,8,1,4084,40,42,0,2560,2824,264,FALSE,FALSE,FALSE,FALSE,FALSE,11
+16,1:08:04,47:04,The Tourist (unmastered near-final version),Unclear if this is the finished mix as there are other mixes on disc 17.,4,8,1,4084,4,47,0,2824,3150,326,FALSE,FALSE,FALSE,FALSE,FALSE,12
+16,1:08:04,52:30,A Reminder (unmastered final version),,4,8,1,4084,30,52,0,3150,3385,235,FALSE,FALSE,FALSE,FALSE,FALSE,13
+16,1:08:04,56:25,Lift (“finished mix” #1)⭐,,4,8,1,4084,25,56,0,3385,3615,230,FALSE,FALSE,TRUE,FALSE,FALSE,14
+16,1:08:04,1:00:15,Lift (“finished mix” #2)⭐,,4,8,1,4084,15,0,1,3615,3839,224,FALSE,FALSE,TRUE,FALSE,FALSE,15
+16,1:08:04,1:03:59,Noise - Fitter Happier beeps,,4,8,1,4084,59,3,1,3839,3853,14,FALSE,FALSE,FALSE,FALSE,FALSE,16
+16,1:08:04,1:04:13,Polyethylene Pt. 2 - Late Mix w/ Vocal Effect,,4,8,1,4084,13,4,1,3853,4073,220,FALSE,FALSE,FALSE,FALSE,FALSE,17
+16,1:08:04,1:07:53,Noise - The Tourist,,4,8,1,4084,53,7,1,4073,4084,11,FALSE,FALSE,FALSE,FALSE,FALSE,18
+17,0:26:49,0:00,The Tourist (unmastered near-final version),,49,26,0,1609,0,0,0,0,325,325,FALSE,FALSE,FALSE,FALSE,FALSE,1
+17,0:26:49,05:25,The Tourist (Louder Choir) (unmastered near-final version),,49,26,0,1609,25,5,0,325,658,333,FALSE,FALSE,FALSE,FALSE,FALSE,2
+17,0:26:49,10:58,Polyethylene Pt. 2 (near-final version),"With its own count-in. Close to album version. Slightly different vocals, less compressed.",49,26,0,1609,58,10,0,658,893,235,FALSE,FALSE,FALSE,FALSE,FALSE,3
+17,0:26:49,14:53,Polyethylene Pt. 2 (Less Bass and Snare) (near-final version),"According to Thom’s note, has less bass and snare.",49,26,0,1609,53,14,0,893,1118,225,FALSE,FALSE,FALSE,FALSE,FALSE,4
+17,0:26:49,18:38,Fitter Happier - Unmastered Album Version,,49,26,0,1609,38,18,0,1118,1256,138,FALSE,FALSE,FALSE,FALSE,FALSE,5
+17,0:26:49,20:56,unknown song 17-1 (lyric - 'tomorrow night in Paris') [Thom solo] 🌚,“Everybody wants you but nobody wants you”,49,26,0,1609,56,20,0,1256,1526,270,TRUE,FALSE,FALSE,FALSE,FALSE,6
+17,0:26:49,25:26,unknown song 17-2 (lyric - 'tomorrow night in Paris') [Thom solo] 🌚,,49,26,0,1609,26,25,0,1526,1609,83,TRUE,FALSE,FALSE,FALSE,FALSE,7
+18,0:41:52,0:00,[chatter/wind noise],“Hello… It’s working…”,52,41,0,2512,0,0,0,0,68,68,FALSE,FALSE,FALSE,FALSE,FALSE,1
+18,0:41:52,1:08,A Reminder 18-1 [Thom A Cappella],Thom singing quietly by himself outside,52,41,0,2512,8,1,0,68,233,165,FALSE,FALSE,FALSE,FALSE,FALSE,2
+18,0:41:52,3:53,[wind noise],,52,41,0,2512,53,3,0,233,296,63,FALSE,FALSE,FALSE,FALSE,FALSE,3
+18,0:41:52,4:56,A Reminder 18-2 [Thom A Cappella],,52,41,0,2512,56,4,0,296,431,135,FALSE,FALSE,FALSE,FALSE,FALSE,4
+18,0:41:52,7:11,[wind noise],,52,41,0,2512,11,7,0,431,464,33,FALSE,FALSE,FALSE,FALSE,FALSE,5
+18,0:41:52,7:44,A Reminder 18-3 [Thom A Cappella - fragment],Cut off at the end,52,41,0,2512,44,7,0,464,611,147,FALSE,FALSE,FALSE,FALSE,FALSE,6
+18,0:41:52,10:11,A Reminder 18-4 [Thom A Cappella],,52,41,0,2512,11,10,0,611,621,10,FALSE,FALSE,FALSE,FALSE,FALSE,7
+18,0:41:52,10:21,A Reminder 18-5 [Thom A Cappella],,52,41,0,2512,21,10,0,621,725,104,FALSE,FALSE,FALSE,FALSE,FALSE,8
+18,0:41:52,12:05,A Reminder 18-6 [Thom A Cappella],In a new key,52,41,0,2512,5,12,0,725,878,153,FALSE,FALSE,FALSE,FALSE,FALSE,9
+18,0:41:52,14:38,unknown song 18-1 (lyric - 'what did you mean') [Thom solo] 🌚,,52,41,0,2512,38,14,0,878,1033,155,TRUE,FALSE,FALSE,FALSE,FALSE,10
+18,0:41:52,17:13,unknown song 18-2 (lyric - 'what did you mean') [Thom solo] 🌚,,52,41,0,2512,13,17,0,1033,1168,135,TRUE,FALSE,FALSE,FALSE,FALSE,11
+18,0:41:52,19:28,unknown song 18-3 (lyric - 'what did you mean') [Thom solo] 🌚,"Clearer vocals
+“That wasn’t a shooting star, that was an airplane landing”",52,41,0,2512,28,19,0,1168,1282,114,TRUE,FALSE,FALSE,FALSE,FALSE,12
+18,0:41:52,21:22,unknown song 18-4 (lyric - 'what did you mean') [Thom solo] 🌚,,52,41,0,2512,22,21,0,1282,1323,41,TRUE,FALSE,FALSE,FALSE,FALSE,13
+18,0:41:52,22:03,"unknown song (lyric - 'you're a sleazy bastard, you're no friend of mine') [Thom solo] 🌚","Rock/bluesy
 “I am the sun and the moon”
-Cut off",52,41,0,2512,21,22,0,1341,1551,210,TRUE,FALSE,FALSE,FALSE,FALSE,15
-18,"00:41:52","25:51","Noise - phone ringing (18-16)",NA,52,41,0,2512,51,25,0,1551,1563,12,FALSE,FALSE,FALSE,FALSE,FALSE,16
-18,"00:41:52","26:03","Thom beatboxing (18-17) 🤤⭐","Best song in this compilation hands down",52,41,0,2512,3,26,0,1563,1595,32,FALSE,TRUE,TRUE,FALSE,FALSE,17
-18,"00:41:52","26:35","Exit Music - Late Mix (18-18)","Background voices at “sing us a song” are different. Definitely the album take of everything else.",52,41,0,2512,35,26,0,1595,1877,282,FALSE,FALSE,FALSE,FALSE,FALSE,18
-18,"00:41:52","31:17","Silence (18-19)",NA,52,41,0,2512,17,31,0,1877,1884,7,FALSE,FALSE,FALSE,FALSE,FALSE,19
-18,"00:41:52","31:24","No Surprises - Late Mix #2 (18-20)","Different vocal take from album version. Original recorded speed; half-step down from album version. Same as tape 15?",52,41,0,2512,24,31,0,1884,2131,247,FALSE,FALSE,FALSE,FALSE,FALSE,20
-18,"00:41:52","35:31","Paranoid Android - Unmastered Album Version (18-21)",NA,52,41,0,2512,31,35,0,2131,2512,381,FALSE,FALSE,FALSE,FALSE,FALSE,21
+Cut off",52,41,0,2512,3,22,0,1323,1545,222,TRUE,FALSE,FALSE,FALSE,FALSE,14
+18,0:41:52,25:45,Thom beatboxing to Laurie’s Theme from Halloween 🤤⭐,Best song in this compilation hands down,52,41,0,2512,45,25,0,1545,1587,42,FALSE,TRUE,TRUE,FALSE,FALSE,15
+18,0:41:52,26:27,Exit Music - Late Mix [duplicate],Background voices at “sing us a song” are different. Definitely the album take of everything else.,52,41,0,2512,27,26,0,1587,1867,280,FALSE,FALSE,FALSE,FALSE,FALSE,16
+18,0:41:52,31:07,No Surprises - Late Mix #2 [duplicate],Different vocal take from album version. Original recorded speed; half-step down from album version. Same as tape 15?,52,41,0,2512,7,31,0,1867,2124,257,FALSE,FALSE,FALSE,FALSE,FALSE,17
+18,0:41:52,35:24,Paranoid Android - Unmastered Album Version [duplicate],,52,41,0,2512,24,35,0,2124,2512,388,FALSE,FALSE,FALSE,FALSE,FALSE,18


### PR DESCRIPTION
Contrary to what is stated in the instructions, the metadata does not match the files released by the band on Bandcamp. This pull request fixes timestamps to fit the Bandcamp release.

Additionally, titles and comments were updated with respect to the latest version of the [group document](https://docs.google.com/document/d/1kA8u6UhjbutZ-b7TXzmX4qkOTg6nGC1vPg50WwCcZyo/preview) (August 25, 2019).

One bogus timestamp was corrected on disc 11.

Resulting file is a combination of:
- first five columns transformed from the document
- other columns generated programmatically

It is a valid CSV file, and was successfully used with the splitter.